### PR TITLE
Enable assembly plugin for a jar with deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,25 @@
                     <target>1.5</target>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+	                <execution>
+	                  <id>make-assembly</id>
+	                  <phase>package</phase>
+	                  <goals>
+	                      <goal>single</goal>
+	                  </goals>
+	                </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>


### PR DESCRIPTION
Adds a maven-assembly-plugin section to the pom.xml which allows to
construct a single jar containing all dependencies.
