### PR TITLE
Comply to spec when reading data message old mac keys

### DIFF
--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -322,7 +322,7 @@ public class SerializationUtils {
 						byte[] ctr = otr.readCtr();
 						byte[] encryptedMessage = otr.readData();
 						byte[] mac = otr.readMac();
-						byte[] oldMacKeys = otr.readMac();
+						byte[] oldMacKeys = otr.readData();
 						DataMessage dataMessage =
 								new DataMessage(protocolVersion, flags, senderKeyID,
 								recipientKeyID, nextDH, ctr, encryptedMessage, mac,


### PR DESCRIPTION
The "Old MAC keys to be revealed" field is a DATA field according to
the OTR protocol specification of all versions. Hence, reading it as a
(single) mac address of 20 bytes is wrong in two senses:
1. it might be empty or contain more than one address, which would be
   ignored then
2. a DATA field contains a 4 byte length header, which would be read as
   the first 4 bytes of the first mac address.

This commit correctly parses the field as a DATA field.
