### PR TITLE
Improve parsing safety

### DIFF
--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -322,7 +322,7 @@ public class SerializationUtils {
 						byte[] ctr = otr.readCtr();
 						byte[] encryptedMessage = otr.readData();
 						byte[] mac = otr.readMac();
-						byte[] oldMacKeys = otr.readMac();
+						byte[] oldMacKeys = otr.readData();
 						DataMessage dataMessage =
 								new DataMessage(protocolVersion, flags, senderKeyID,
 								recipientKeyID, nextDH, ctr, encryptedMessage, mac,

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -3,7 +3,10 @@ package net.java.otr4j.session;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.java.otr4j.OtrEngineListener;
 import net.java.otr4j.OtrException;
@@ -18,6 +21,9 @@ public interface Session {
 		public static final int TWO = 2;
 
 		public static final int THREE = 3;
+
+		public static final Set<Integer> ALL = new HashSet<Integer>(
+				Arrays.asList(new Integer[] { ONE, TWO, THREE }));
 	}
 
 	public abstract SessionStatus getSessionStatus();

--- a/src/test/java/net/java/otr4j/io/IOTest.java
+++ b/src/test/java/net/java/otr4j/io/IOTest.java
@@ -10,6 +10,7 @@ import javax.crypto.interfaces.DHPublicKey;
 import net.java.otr4j.crypto.OtrCryptoEngineImpl;
 import net.java.otr4j.io.messages.DHKeyMessage;
 import net.java.otr4j.io.messages.RevealSignatureMessage;
+import net.java.otr4j.session.Session.OTRv;
 
 public class IOTest extends junit.framework.TestCase {
 
@@ -107,7 +108,7 @@ public class IOTest extends junit.framework.TestCase {
 	public void testIODHKeyMessage() throws Exception {
 		KeyPair pair = new OtrCryptoEngineImpl().generateDHKeyPair();
 
-		DHKeyMessage source = new DHKeyMessage(0, (DHPublicKey) pair
+		DHKeyMessage source = new DHKeyMessage(OTRv.THREE, (DHPublicKey) pair
 				.getPublic());
 
 		String base64 = SerializationUtils.toString(source);

--- a/src/test/java/net/java/otr4j/io/SerializationUtilsTest.java
+++ b/src/test/java/net/java/otr4j/io/SerializationUtilsTest.java
@@ -1,5 +1,7 @@
 package net.java.otr4j.io;
 
+import java.io.IOException;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -35,4 +37,11 @@ public class SerializationUtilsTest {
 	public void testOTRv3FragmentNotOTREncoded() {
 		Assert.assertFalse(SerializationUtils.otrEncoded("?OTR|5a73a599|27e31597,00001,00003,?OTR:AAMDJ+MVmSfjFZcAAAAAAQAAAAIAAADA1g5IjD1ZGLDVQEyCgCyn9hbrL3KAbGDdzE2ZkMyTKl7XfkSxh8YJnudstiB74i4BzT0W2haClg6dMary/jo9sMudwmUdlnKpIGEKXWdvJKT+hQ26h9nzMgEditLB8v,"));
 	}
+
+	@Test(expected = IOException.class)
+	public void testToMessageWrongProtocolVersion() throws Exception {
+		SerializationUtils
+				.toMessage("?OTR:AAQDdAYBciqzcLcAAAAAAQAAAAIAAADAh7NAcXJNpXa8qw89tvx4eoxhR3iaTx4omdj34HRpgMXDGIR7Kp4trQ+L5k8INcse58RJWHQPYW+dgKMkwrpCNJIgaqjzaiJC5+QPylSchrAB78MNZiCLXW7YU3dSic1Pm0dpa57wwiFp7sfSm00GEcE7M1bRe7Pr1zgb8KP/5PJUeI7IVmYTDj5ONWUsyoocD40RQ+Bu+I7GLgb7WICGZ6mpof3UGEFFmJLB5lDfunhCqb0d3MRP0G6k/8YJzjIlAAAAAAAAAAEAAAAF8VtymMJceqLiPIYPjRTLmlr5gQPirDY87QAAAAA=.");
+	}
+
 }


### PR DESCRIPTION
This pull request improves the safety in parsing encrypted OTR messages by adding checks for supported protocol versions and the amount of bytes read from an OtrInputStream. So far, several conditions were not handled at all and resulted in unexpected error conditions.

This PR depends on #3 and the first commit of this commit is simply the cherry-picked commit from #3. So when merging, this commit needs to be removed in case #3 has been merged before. Without #3, the additional checks in this PR cause the unit tests to fail due to the spec mismatch reported in #3.
