### PR TITLE
Fix verify method : the 2 arrays compared were the same -> use this.xEnc...

### DIFF
--- a/src/main/java/net/java/otr4j/io/messages/SignatureMessage.java
+++ b/src/main/java/net/java/otr4j/io/messages/SignatureMessage.java
@@ -14,7 +14,7 @@ import net.java.otr4j.crypto.OtrCryptoEngineImpl;
 import net.java.otr4j.io.SerializationUtils;
 
 /**
- * 
+ *
  * @author George Politis
  */
 public class SignatureMessage extends AbstractEncodedMessage {
@@ -52,7 +52,7 @@ public class SignatureMessage extends AbstractEncodedMessage {
 		byte[] xEncryptedMAC = new OtrCryptoEngineImpl().sha256Hmac160(
 				xbEncrypted, key);
 		// Verify signature.
-		return Arrays.equals(xEncryptedMAC, xEncryptedMAC);
+		return Arrays.equals(this.xEncryptedMAC, xEncryptedMAC);
 	}
 
 	@Override


### PR DESCRIPTION
In the verify method there is a mistake when comparing two arrays, the fix is simple : use the xEncryptedMAC instance of the current SignatureMessage object ("this.xEncryptedMAC") instead of the local one.
