### PR TITLE
Removed local deployment repository from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,10 +99,4 @@
             </plugin>
         </plugins>
     </build>
-    <distributionManagement>
-        <repository>
-            <id>gh-pages</id>
-            <url>file:///${basedir}/../gh-pages/repository/</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
The deployment repository specified in the pom.xml so far was probably
not usable for anyone without a very specific setup since it created a
filesystem repository one level above the otr4j source code. Such
specific cases can be handled via command line arguments for maven and
should not be the default.
