### PR TITLE
Explicit character encoding for all string-byte conversions.

### DIFF
--- a/src/main/java/net/java/otr4j/crypto/SM.java
+++ b/src/main/java/net/java/otr4j/crypto/SM.java
@@ -667,7 +667,7 @@ public class SM {
 		String ss = Util.bytesToHexString(res.toByteArray());
 		System.out.println(ss);
 		
-		byte[] secret1 = "abcdef".getBytes();
+		byte[] secret1 = "abcdef".getBytes(SerializationUtils.UTF8);
 		SMState a = new SMState();
 		SMState b = new SMState();
 		

--- a/src/main/java/net/java/otr4j/crypto/Util.java
+++ b/src/main/java/net/java/otr4j/crypto/Util.java
@@ -19,6 +19,8 @@
 
 package net.java.otr4j.crypto;
 
+import net.java.otr4j.io.SerializationUtils;
+
 public class Util {
 	public static void checkBytes(String s, byte[] bytes) {
 		String hexString = new String();
@@ -45,7 +47,7 @@ public class Util {
 	}
 	
 	static byte[] hexStringToBytes(String s){
-		byte[] sbytes = s.getBytes();
+		byte[] sbytes = s.getBytes(SerializationUtils.ASCII);
 		if(sbytes.length%2!=0) return null;
 		byte[] ret = new byte[sbytes.length/2];
 		for(int i=0; i<ret.length; i++){

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,16 @@ import net.java.otr4j.session.Session.OTRv;
  * @author George Politis
  */
 public class SerializationUtils {
+	/**
+	 * Charset for base64-encoded content.
+	 */
+	public static Charset ASCII = Charset.forName("US-ASCII");
+
+	/**
+	 * Charset for message content according to OTR spec.
+	 */
+	public static Charset UTF8 = Charset.forName("UTF-8");
+
 	// Mysterious X IO.
 	public static SignatureX toMysteriousX(byte[] b) throws IOException {
 		ByteArrayInputStream in = new ByteArrayInputStream(b);
@@ -312,7 +323,7 @@ public class SerializationUtils {
                  * So in order to decode the content string we have to get rid of the '.' first.
                  */
 				ByteArrayInputStream bin = new ByteArrayInputStream(Base64
-						.decode(content.substring(0, content.length() - 1).getBytes()));
+						.decode(content.substring(0, content.length() - 1).getBytes(ASCII)));
 				OtrInputStream otr = new OtrInputStream(bin);
 				// We have an encoded message.
 				try {

--- a/src/main/java/net/java/otr4j/session/OtrSm.java
+++ b/src/main/java/net/java/otr4j/session/OtrSm.java
@@ -18,6 +18,7 @@ import net.java.otr4j.crypto.SM;
 import net.java.otr4j.crypto.SM.SMException;
 import net.java.otr4j.crypto.SM.SMState;
 import net.java.otr4j.io.OtrOutputStream;
+import net.java.otr4j.io.SerializationUtils;
 
 public class OtrSm {
     
@@ -121,7 +122,7 @@ public class OtrSm {
 			System.arraycopy(our_fp, 0, combined_buf, 21, 20);
 		}
 		System.arraycopy(sessionId, 0, combined_buf, 41, sessionId.length);
-		System.arraycopy(secret.getBytes(), 0, 
+		System.arraycopy(secret.getBytes(SerializationUtils.UTF8), 0, 
 				combined_buf, 41 + sessionId.length, secret.length());
 
 		MessageDigest sha256;
@@ -145,13 +146,7 @@ public class OtrSm {
 
 		// If we've got a question, attach it to the smpmsg 
 		if (question != null && initiating){
-			byte[] bytes = null;
-			try {
-				bytes = question.getBytes("UTF-8");
-			} catch (UnsupportedEncodingException e) {
-				// Never thrown - all JRE's support UTF-8
-				e.printStackTrace();
-			}
+			byte[] bytes = question.getBytes(SerializationUtils.UTF8);
 			byte[] qsmpmsg = new byte[bytes.length + 1 + smpmsg.length];
 			System.arraycopy(bytes, 0, qsmpmsg, 0, bytes.length);
 			System.arraycopy(smpmsg, 0, qsmpmsg, bytes.length + 1, smpmsg.length);

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -865,12 +865,13 @@ public class Session {
                 byte[] ctr = encryptionKeys.getSendingCtr();
 
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                if (msgText != null && msgText.length() > 0)
+                if (msgText != null && msgText.length() > 0) {
                     try {
-                        out.write(msgText.getBytes("UTF8"));
+                        out.write(msgText.getBytes(SerializationUtils.UTF8));
                     } catch (IOException e) {
                         throw new OtrException(e);
                     }
+                }
 
                 // Append tlvs
                 if (tlvs != null && tlvs.size() > 0) {

--- a/src/test/java/net/java/otr4j/session/OtrFragmenterTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrFragmenterTest.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import net.java.otr4j.OtrEngineHost;
 import net.java.otr4j.OtrPolicy;
+import net.java.otr4j.io.SerializationUtils;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.util.encoders.Base64;
@@ -464,7 +465,7 @@ public class OtrFragmenterTest {
 	@Test
 	public void testFragmentPatternsV3() throws IOException {		
 		final Pattern OTRv3_FRAGMENT_PATTERN = Pattern.compile("^\\?OTR\\|[0-9abcdef]{8}\\|[0-9abcdef]{8},\\d{5},\\d{5},[a-zA-Z0-9\\+/=\\?:]+,$");
-		final String payload = new String(Base64.encode(RandomStringUtils.random(1700).getBytes("UTF-8")));
+		final String payload = new String(Base64.encode(RandomStringUtils.random(1700).getBytes(SerializationUtils.UTF8)));
 		final Session session = createSessionMock(POLICY_V3, 0x0a73a599, 0x00000007);
 		final OtrEngineHost host = host(150);
 		
@@ -484,7 +485,7 @@ public class OtrFragmenterTest {
 	@Test
 	public void testFragmentPatternsV2() throws IOException {		
 		final Pattern OTRv2_FRAGMENT_PATTERN = Pattern.compile("^\\?OTR,\\d{1,5},\\d{1,5},[a-zA-Z0-9\\+/=\\?:]+,$");
-		final String payload = new String(Base64.encode(RandomStringUtils.random(700).getBytes("UTF-8")));
+		final String payload = new String(Base64.encode(RandomStringUtils.random(700).getBytes(SerializationUtils.UTF8)));
 		final Session session = createSessionMock(POLICY_V2, 0, 0);
 		final OtrEngineHost host = host(150);
 		


### PR DESCRIPTION
The OTR spec is quite specific about what encoding they expect for different types of content. This patch makes all character sets for String encoding using getBytes(...) explicit.

2 encodings are used: UTF-8 and US-ASCII. Both are required by the standard, so both should be available in all (decent) JVM's. Message content is explicitly encoded as UTF-8.  The Base64-encoded message content is encoded as ASCII in order to get to the original byte content. (As expected of course.)

Additionally, constants have been defined in SerializationUtils. By using those Charset constants we can avoid some exception handling of UnsupportedEncodingException.

(Small side note: getBytes(Charset) is only available from JDK 1.6. However, maven does not complain, so compiling seems to produce JDK 1.5 compatible code. We could fall back to getBytes(String charset) if we want to be completely 1.5 compatible.)
