### PR TITLE
Update maven pom.xml to jdk 1.6 source/target.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Given that we standardize on java 1.6 (rather than 1.5), update maven pom.xml accordingly.
