### PR TITLE
Force the maven build system for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ jdk:
   - oraclejdk7
   - openjdk7
   - openjdk6
+install: mvn install -DskipTests=true
+script: mvn test


### PR DESCRIPTION
The addition of a gradle build systems made travis prefer this one. Since maven seems to be the preferred build system so far, this forces travis to use maven.
