### PR TITLE
Online code coverage reports using the Coveralls website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
   - openjdk6
 install: mvn install -DskipTests=true
 script: mvn test
+after_success:
+  - mvn coveralls:report

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/otr4j/otr4j/badge.svg?branch=master)](https://coveralls.io/r/otr4j/otr4j?branch=master)
+
 ## Synopsis
 
 otr4j is an implementation of the [OTR (Off The Record) protocol][1]

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,36 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.7</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.2.201409121644</version>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <reporting>
@@ -146,6 +176,11 @@
                         <ruleset>${project.basedir}/codecheck/pmd-rules.xml</ruleset>
                     </rulesets>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.2.201409121644</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <serviceName>travis-ci</serviceName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <reporting>


### PR DESCRIPTION
Based on @cobratbq coverage integration PR #34 this adds publishing of coverage reports to the Coveralls website, which provides a publicly available and free service of archiving the reports and generating trend graphs. Moreover, new pull requests can automatically be marked as failing in case they decrease the code coverage by a specified percentage.

A sample report for this repository is available from my testing branch: https://coveralls.io/r/languitar/otr4j

For this PR to work, someone needs to register this repository with the Coveralls website. Afterwards, everything should work out of the box.
