### PR TITLE
Fix and speed up SMPTest

### DIFF
--- a/src/test/java/net/java/otr4j/test/SMPTest.java
+++ b/src/test/java/net/java/otr4j/test/SMPTest.java
@@ -1,10 +1,12 @@
 
 package net.java.otr4j.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -13,56 +15,92 @@ import net.java.otr4j.session.Session;
 import net.java.otr4j.test.dummyclient.DummyClient;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
- * test that Socialist Millionaire Protocol verification is working
+ * Test that Socialist Millionaire Protocol verification is working.
  *
  * @author Hans-Christoph Steiner
  */
+@RunWith(Parameterized.class)
 public class SMPTest {
 
-    String snippets[] = {
-            // TODO these currently cause an Exception when used as question:
-            // "nullshere:\0\0andhere:\0",
-            // "tabbackslashT\t",
-            // "backslashR\r",
-            // "NEWLINE\n",
-            "",
-            "བོད་རིགས་ཀྱི་བོད་སྐད་བརྗོད་པ་དང་ བོད་རིགས་མང་ཆེ་བ་ནི་ནང་ཆོས་བྱེད་པ་དང་",
-            "تبتی قوم (Tibetan people)",
-            "Учените твърдят, че тибетците нямат",
-            "Câung-cŭk (藏族, Câung-ngṳ̄: བོད་པ་)",
-            "チベット系民族（チベットけいみんぞく）",
-            "原始汉人与原始藏缅人约在公元前4000年左右分开。",
-            "Տիբեթացիներ (ինքնանվանումը՝ պյոբա),",
-            "... Gezginci olarak",
-            "شْتَن Xotan",
-            "Tibeťané jsou",
-            "ئاچاڭ- تىبەت مىللىتى",
-            "Miscellaneous Symbols and Pictographs[1][2]Official Unicode Consortium code chart (PDF)",
-            "Royal Thai (ราชาศัพท์)",
-            "טיילאנדיש123 (ภาษาไทย)",
-            "ជើងអក្សរ cheung âksâr",
-            "중화인민공화국에서는 기본적으로 한족은 ",
-            "पाठ्यांशः अत्र उपलभ्यतेसर्जनसामान्यलक्षणम्/Share-",
-            "திபெத்துக்கு வெகள்",
-            "អក្សរសាស្រ្តខែ្មរមានប្រវ៌ត្តជាងពីរពាន់ឆ្នាំមកហើយ ",
-    };
+    private static final int DEFAULT_TIMEOUT_MS = 2000;
+    private static final String SIMPLE_PASSWORD = "MATCH";
+    private final String snippet;
 
-    boolean runSMPTest(String question, String alicePassword, String bobPassword)
-            throws InterruptedException, OtrException {
-        CountDownLatch aliceLock = new CountDownLatch(1);
-        CountDownLatch bobLock = new CountDownLatch(1);
-        DummyClient[] convo = DummyClient.getConversation(aliceLock, bobLock);
-        DummyClient alice = convo[0];
-        DummyClient bob = convo[1];
+    public SMPTest(final String snippet) {
+        this.snippet = snippet;
+    }
+
+    // TODO these currently cause an Exception when used as question:
+    // "nullshere:\0\0andhere:\0",
+    // "tabbackslashT\t",
+    // "backslashR\r",
+    // "NEWLINE\n",
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays
+                .asList(new Object[][] {
+                        { "plainAscii" },
+                        { "" },
+                        { "བོད་རིགས་ཀྱི་བོད་སྐད་བརྗོད་པ་དང་ "
+                                + "བོད་རིགས་མང་ཆེ་བ་ནི་ནང་ཆོས་བྱེད་པ་དང་" },
+                        { "تبتی قوم (Tibetan people)" },
+                        { "Учените твърдят, че тибетците нямат" },
+                        { "Câung-cŭk (藏族, Câung-ngṳ̄: བོད་པ་)" },
+                        { "チベット系民族（チベットけいみんぞく）" },
+                        { "原始汉人与原始藏缅人约在公元前4000年左右分开。" },
+                        { "Տիբեթացիներ (ինքնանվանումը՝ պյոբա)," },
+                        { "... Gezginci olarak" },
+                        { "شْتَن Xotan" },
+                        { "Tibeťané jsou" },
+                        { "ئاچاڭ- تىبەت مىللىتى" },
+                        { "Miscellaneous Symbols and Pictographs[1][2]"
+                                + "Official Unicode Consortium code chart (PDF)" },
+                        { "Royal Thai (ราชาศัพท์)" }, { "טיילאנדיש123 (ภาษาไทย)" },
+                        { "ជើងអក្សរ cheung âksâr" }, { "중화인민공화국에서는 기본적으로 한족은 " },
+                        { "पाठ्यांशः अत्र उपलभ्यतेसर्जनसामान्यलक्षणम्/Share-" },
+                        { "திபெத்துக்கு வெகள்" },
+                        { "អក្សរសាស្រ្តខែ្មរមានប្រវ៌ត្តជាងពីរពាន់ឆ្នាំមកហើយ " }, });
+    }
+
+    private static class SMPTestResult {
+
+        private final int aliceResult;
+        private final int bobResult;
+
+        public SMPTestResult(final int aliceResult, final int bobResult) {
+            this.aliceResult = aliceResult;
+            this.bobResult = bobResult;
+        }
+
+        public int getAliceResult() {
+            return this.aliceResult;
+        }
+
+        public int getBobResult() {
+            return this.bobResult;
+        }
+
+    }
+
+    SMPTestResult runSMPTest(final String question, final String alicePassword,
+            final String bobPassword) throws InterruptedException, OtrException {
+        final CountDownLatch aliceLock = new CountDownLatch(1);
+        final CountDownLatch bobLock = new CountDownLatch(1);
+        final DummyClient[] convo = DummyClient.getConversation(aliceLock, bobLock);
+        final DummyClient alice = convo[0];
+        final DummyClient bob = convo[1];
 
         assertTrue(DummyClient.forceStartOtr(alice, bob));
-        assertTrue(alice.getVerified() == DummyClient.NOTSET);
-        assertTrue(bob.getVerified() == DummyClient.NOTSET);
+        assertEquals(DummyClient.NOTSET, alice.getVerified());
+        assertEquals(DummyClient.NOTSET, bob.getVerified());
 
-        Session aliceSession = alice.getSession();
-        Session bobSession = bob.getSession();
+        final Session aliceSession = alice.getSession();
+        final Session bobSession = bob.getSession();
 
         assertFalse(aliceSession.isSmpInProgress());
         assertFalse(bobSession.isSmpInProgress());
@@ -70,69 +108,65 @@ public class SMPTest {
 
         assertTrue(aliceSession.isSmpInProgress());
         assertFalse(bobSession.isSmpInProgress());
-        bob.pollReceivedMessage(); // SMP1Q
+        bob.pollReceivedMessage();
 
         // wait for the password prompt that is triggered by:
         // OtrEngineHost.askForSecret()
-        bobLock.await(2000, TimeUnit.MILLISECONDS);
+        assertTrue(bobLock.await(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         bobSession.respondSmp(question, bobPassword);
         assertTrue(aliceSession.isSmpInProgress());
         assertTrue(bobSession.isSmpInProgress());
 
-        alice.pollReceivedMessage(); // SMP2
+        // SMP2
+        alice.pollReceivedMessage();
         assertTrue(aliceSession.isSmpInProgress());
         assertTrue(bobSession.isSmpInProgress());
 
-        bob.pollReceivedMessage(); // SMP3
+        // SMP3
+        bob.pollReceivedMessage();
         assertTrue(aliceSession.isSmpInProgress());
         assertFalse(bobSession.isSmpInProgress());
 
-        alice.pollReceivedMessage(); // SMP4
+        // SMP4
+        alice.pollReceivedMessage();
         assertFalse(aliceSession.isSmpInProgress());
         assertFalse(bobSession.isSmpInProgress());
 
         // wait for SMP to complete
-        aliceLock.await(2000, TimeUnit.MILLISECONDS);
+        assertTrue(aliceLock.await(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        return alice.getVerified() == DummyClient.VERIFIED
-                && bob.getVerified() == DummyClient.VERIFIED;
+        return new SMPTestResult(alice.getVerified(), bob.getVerified());
     }
 
-    @Test
-    public void testGoodPasswordVerify() throws OtrException, IOException, InterruptedException {
-        assertTrue(runSMPTest(null, "goodPassword", "goodPassword"));
-        System.out.print(".");
-        for (String password : snippets) {
-            assertTrue(runSMPTest(null, password, password));
-            System.out.print(".");
-        }
-        String question = "this is the first question:";
-        for (String password : snippets) {
-            assertTrue(runSMPTest(question, password, password));
-            question = password;
-            System.out.print(".");
-        }
-        System.out.println("");
+    @Test(timeout = DEFAULT_TIMEOUT_MS)
+    public void goodPasswordNoQuestion() throws Exception {
+        final SMPTestResult result = runSMPTest(null, this.snippet, this.snippet);
+        assertEquals(DummyClient.VERIFIED, result.getAliceResult());
+        assertEquals(DummyClient.VERIFIED, result.getBobResult());
     }
 
-    @Test
-    public void testBadPasswordVerify() throws OtrException, IOException, InterruptedException {
-        assertFalse(runSMPTest(null, "goodPassword", "BADpassword"));
-        System.out.print(".");
-        String previousPassword = "BADpassword";
-        for (String password : snippets) {
-            assertFalse(runSMPTest(null, password, previousPassword));
-            previousPassword = password;
-            System.out.print(".");
-        }
-        String question = "this is the first question:";
-        for (String password : snippets) {
-            assertFalse(runSMPTest(question, password, previousPassword));
-            previousPassword = password;
-            question = password;
-            System.out.print(".");
-        }
-        System.out.println("");
+    @Test(timeout = DEFAULT_TIMEOUT_MS)
+    public void goodPasswordWithQuestion() throws Exception {
+        // isolate the effects of encodings to the question
+        final SMPTestResult result = runSMPTest(this.snippet, SIMPLE_PASSWORD, SIMPLE_PASSWORD);
+        assertEquals(DummyClient.VERIFIED, result.getAliceResult());
+        assertEquals(DummyClient.VERIFIED, result.getBobResult());
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT_MS)
+    public void badPasswordNoQuestion() throws Exception {
+        final SMPTestResult result = runSMPTest(null, this.snippet, "BAD" + this.snippet);
+        assertEquals(DummyClient.UNVERIFIED, result.getAliceResult());
+        assertEquals(DummyClient.UNVERIFIED, result.getBobResult());
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT_MS)
+    public void badPasswordWithQuestion() throws Exception {
+        // isolate the effects of encodings to the question
+        final SMPTestResult result =
+                runSMPTest(this.snippet, SIMPLE_PASSWORD, SIMPLE_PASSWORD + "NOT");
+        assertEquals(DummyClient.UNVERIFIED, result.getAliceResult());
+        assertEquals(DummyClient.UNVERIFIED, result.getBobResult());
     }
 }

--- a/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
+++ b/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
@@ -57,11 +57,11 @@ public class DummyClient {
     }
 
     public static DummyClient[] getConversation(CountDownLatch aliceLock, CountDownLatch bobLock) {
-		DummyClient bob = new DummyClient("Bob@Wonderland", aliceLock);
+		DummyClient bob = new DummyClient("Bob@Wonderland", bobLock);
 		bob.setPolicy(new OtrPolicy(OtrPolicy.ALLOW_V2 | OtrPolicy.ALLOW_V3
 				| OtrPolicy.ERROR_START_AKE));
 
-		DummyClient alice = new DummyClient("Alice@Wonderland", bobLock);
+		DummyClient alice = new DummyClient("Alice@Wonderland", aliceLock);
 		alice.setPolicy(new OtrPolicy(OtrPolicy.ALLOW_V2
 				| OtrPolicy.ALLOW_V3 | OtrPolicy.ERROR_START_AKE));
 


### PR DESCRIPTION
SMPTest was slow because awaiting the first lock always timed out. If I understand things correctly, the locks in `DummyClient` were mixed up. This is fixed in a2c2c60. Moreover, this improves the code of SMPTest, which includes asserting that a lock never times out.

This will resolve #35.
