### PR TITLE
Maven security improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-  - openjdk6
 install: mvn install -DskipTests=true
 script: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
         </dependency>
     </dependencies>
     <build>
+        <!-- To define the plugin version in your parent POM -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.s4u.plugins</groupId>
+                    <artifactId>pgpverify-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -161,6 +171,17 @@
                             <rules>
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.s4u.plugins</groupId>
+                <artifactId>pgpverify-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>0.21</version>
     <packaging>jar</packaging>
     <name>otr4j library</name>
-    <url>http://github.com/otr4j/otr4j</url>
+    <url>https://github.com/otr4j/otr4j</url>
     <description>
         otr4j is an implementation of the OTR (Off The Record) protocol in java.
 
@@ -41,6 +41,25 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <!-- force HTTPS access for downloading jars -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
I knew that maven didn't have great security, but I didn't realize it was actually terrifically bad by default:
- http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/

These two commits should help improve the situation by first, forcing HTTPS for all jar downloads, and second, verifying the PGP signature, when available, on the downloaded files.  People familiar with maven probably have already taken steps to do this globally on their machines, but still, we shouldn't leave newcomers wide open to such attacks.
