### PR TITLE
SMP TLV tweaks

### DIFF
--- a/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
+++ b/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
 
-import org.bouncycastle.util.encoders.Base64;
-
 import net.java.otr4j.crypto.OtrCryptoEngine;
 import net.java.otr4j.crypto.OtrCryptoException;
 import net.java.otr4j.session.SessionID;
+
+import org.bouncycastle.util.encoders.Base64;
 
 public class OtrKeyManagerImpl implements OtrKeyManager {
 
@@ -164,7 +164,7 @@ public class OtrKeyManagerImpl implements OtrKeyManager {
 		PublicKey pubKey = keyPair.getPublic();
 
 		try {
-			return new OtrCryptoEngine().getFingerprint(pubKey);
+			return OtrCryptoEngine.getFingerprint(pubKey);
 		} catch (OtrCryptoException e) {
 			e.printStackTrace();
 			return null;
@@ -180,7 +180,7 @@ public class OtrKeyManagerImpl implements OtrKeyManager {
 		PublicKey pubKey = keyPair.getPublic();
 
 		try {
-			return new OtrCryptoEngine().getFingerprintRaw(pubKey);
+			return OtrCryptoEngine.getFingerprintRaw(pubKey);
 		} catch (OtrCryptoException e) {
 			e.printStackTrace();
 			return null;
@@ -192,7 +192,7 @@ public class OtrKeyManagerImpl implements OtrKeyManager {
 		if (remotePublicKey == null)
 			return null;
 		try {
-			return new OtrCryptoEngine().getFingerprint(remotePublicKey);
+			return OtrCryptoEngine.getFingerprint(remotePublicKey);
 		} catch (OtrCryptoException e) {
 			e.printStackTrace();
 			return null;

--- a/src/main/java/net/java/otr4j/OtrSessionManager.java
+++ b/src/main/java/net/java/otr4j/OtrSessionManager.java
@@ -31,7 +31,10 @@ public class OtrSessionManager {
     private Map<SessionID, Session> sessions;
 
     /**
-     * Get an OTR session.
+     * Fetches the existing session with this {@link SessionID} or creates a new
+     * {@link Session} if one does not exist.
+     *
+     * @param sessionID
      * @return MVN_PASS_JAVADOC_INSPECTION
      */
     public Session getSession(SessionID sessionID) {

--- a/src/main/java/net/java/otr4j/crypto/OtrCryptoEngine.java
+++ b/src/main/java/net/java/otr4j/crypto/OtrCryptoEngine.java
@@ -57,8 +57,7 @@ public class OtrCryptoEngine {
     public static final String MODULUS_TEXT = "00FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA237327FFFFFFFFFFFFFFFF";
     public static final BigInteger MODULUS = new BigInteger(MODULUS_TEXT, 16);
     public static final BigInteger BIGINTEGER_TWO = BigInteger.valueOf(2);
-    public static final BigInteger MODULUS_MINUS_TWO = MODULUS
-            .subtract(BIGINTEGER_TWO);
+    public static final BigInteger MODULUS_MINUS_TWO = MODULUS.subtract(BIGINTEGER_TWO);
 
     public static String GENERATOR_TEXT = "2";
     public static BigInteger GENERATOR = new BigInteger(GENERATOR_TEXT, 10);
@@ -74,7 +73,11 @@ public class OtrCryptoEngine {
 
     public static final int DSA_PUB_TYPE = 0;
 
-    public KeyPair generateDHKeyPair() throws OtrCryptoException {
+    private OtrCryptoEngine() {
+        // this class is never instantiated, it only has static methods
+    }
+
+    public static KeyPair generateDHKeyPair() throws OtrCryptoException {
 
         // Generate a AsymmetricCipherKeyPair using BC.
         DHParameters dhParams = new DHParameters(MODULUS, GENERATOR, null,
@@ -111,12 +114,12 @@ public class OtrCryptoEngine {
         }
     }
 
-    public DHPublicKey getDHPublicKey(byte[] mpiBytes)
+    public static DHPublicKey getDHPublicKey(byte[] mpiBytes)
             throws OtrCryptoException {
         return getDHPublicKey(new BigInteger(mpiBytes));
     }
 
-    public DHPublicKey getDHPublicKey(BigInteger mpi) throws OtrCryptoException {
+    public static DHPublicKey getDHPublicKey(BigInteger mpi) throws OtrCryptoException {
         DHPublicKeySpec pubKeySpecs = new DHPublicKeySpec(mpi, MODULUS,
                 GENERATOR);
         try {
@@ -127,11 +130,11 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] sha256Hmac(byte[] b, byte[] key) throws OtrCryptoException {
-        return this.sha256Hmac(b, key, 0);
+    public static byte[] sha256Hmac(byte[] b, byte[] key) throws OtrCryptoException {
+        return sha256Hmac(b, key, 0);
     }
 
-    public byte[] sha256Hmac(byte[] b, byte[] key, int length)
+    public static byte[] sha256Hmac(byte[] b, byte[] key, int length)
             throws OtrCryptoException {
 
         SecretKeySpec keyspec = new SecretKeySpec(key, "HmacSHA256");
@@ -159,7 +162,7 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] sha1Hmac(byte[] b, byte[] key, int length)
+    public static byte[] sha1Hmac(byte[] b, byte[] key, int length)
             throws OtrCryptoException {
 
         try {
@@ -182,11 +185,11 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] sha256Hmac160(byte[] b, byte[] key) throws OtrCryptoException {
+    public static byte[] sha256Hmac160(byte[] b, byte[] key) throws OtrCryptoException {
         return sha256Hmac(b, key, SerializationConstants.TYPE_LEN_MAC);
     }
 
-    public byte[] sha256Hash(byte[] b) throws OtrCryptoException {
+    public static byte[] sha256Hash(byte[] b) throws OtrCryptoException {
         try {
             MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
             sha256.update(b, 0, b.length);
@@ -196,7 +199,7 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] sha1Hash(byte[] b) throws OtrCryptoException {
+    public static byte[] sha1Hash(byte[] b) throws OtrCryptoException {
         try {
             MessageDigest sha256 = MessageDigest.getInstance("SHA-1");
             sha256.update(b, 0, b.length);
@@ -206,7 +209,7 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] aesDecrypt(byte[] key, byte[] ctr, byte[] b)
+    public static byte[] aesDecrypt(byte[] key, byte[] ctr, byte[] b)
             throws OtrCryptoException {
 
         AESFastEngine aesDec = new AESFastEngine();
@@ -229,7 +232,7 @@ public class OtrCryptoEngine {
         return aesOutLwDec;
     }
 
-    public byte[] aesEncrypt(byte[] key, byte[] ctr, byte[] b)
+    public static byte[] aesEncrypt(byte[] key, byte[] ctr, byte[] b)
             throws OtrCryptoException {
 
         AESFastEngine aesEnc = new AESFastEngine();
@@ -251,7 +254,7 @@ public class OtrCryptoEngine {
         return aesOutLwEnc;
     }
 
-    public BigInteger generateSecret(PrivateKey privKey, PublicKey pubKey)
+    public static BigInteger generateSecret(PrivateKey privKey, PublicKey pubKey)
             throws OtrCryptoException {
         try {
             KeyAgreement ka = KeyAgreement.getInstance("DH");
@@ -266,7 +269,7 @@ public class OtrCryptoEngine {
         }
     }
 
-    public byte[] sign(byte[] b, PrivateKey privatekey)
+    public static byte[] sign(byte[] b, PrivateKey privatekey)
             throws OtrCryptoException {
 
         if (!(privatekey instanceof DSAPrivateKey))
@@ -306,7 +309,7 @@ public class OtrCryptoEngine {
         return sig;
     }
 
-    public boolean verify(byte[] b, PublicKey pubKey, byte[] rs)
+    public static boolean verify(byte[] b, PublicKey pubKey, byte[] rs)
             throws OtrCryptoException {
 
         if (!(pubKey instanceof DSAPublicKey))
@@ -322,14 +325,14 @@ public class OtrCryptoEngine {
         return verify(b, pubKey, r, s);
     }
 
-    private Boolean verify(byte[] b, PublicKey pubKey, byte[] r, byte[] s)
+    private static Boolean verify(byte[] b, PublicKey pubKey, byte[] r, byte[] s)
             throws OtrCryptoException {
         Boolean result = verify(b, pubKey, new BigInteger(1, r),
                 new BigInteger(1, s));
         return result;
     }
 
-    private Boolean verify(byte[] b, PublicKey pubKey, BigInteger r,
+    private static Boolean verify(byte[] b, PublicKey pubKey, BigInteger r,
             BigInteger s) throws OtrCryptoException {
 
         if (!(pubKey instanceof DSAPublicKey))
@@ -359,12 +362,12 @@ public class OtrCryptoEngine {
         return result;
     }
 
-    public String getFingerprint(PublicKey pubKey) throws OtrCryptoException {
+    public static String getFingerprint(PublicKey pubKey) throws OtrCryptoException {
         byte[] b = getFingerprintRaw(pubKey);
         return SerializationUtils.byteArrayToHexString(b);
     }
 
-    public byte[] getFingerprintRaw(PublicKey pubKey)
+    public static byte[] getFingerprintRaw(PublicKey pubKey)
             throws OtrCryptoException {
         byte[] b;
         try {
@@ -373,9 +376,9 @@ public class OtrCryptoEngine {
             if (pubKey.getAlgorithm().equals("DSA")) {
                 byte[] trimmed = new byte[bRemotePubKey.length - 2];
                 System.arraycopy(bRemotePubKey, 2, trimmed, 0, trimmed.length);
-                b = new OtrCryptoEngine().sha1Hash(trimmed);
+                b = OtrCryptoEngine.sha1Hash(trimmed);
             } else
-                b = new OtrCryptoEngine().sha1Hash(bRemotePubKey);
+                b = OtrCryptoEngine.sha1Hash(bRemotePubKey);
         } catch (IOException e) {
             throw new OtrCryptoException(e);
         }

--- a/src/main/java/net/java/otr4j/io/OtrInputStream.java
+++ b/src/main/java/net/java/otr4j/io/OtrInputStream.java
@@ -120,7 +120,7 @@ public class OtrInputStream extends FilterInputStream implements
 	public DHPublicKey readDHPublicKey() throws IOException {
 		BigInteger gyMpi = readBigInt();
 		try {
-			return new OtrCryptoEngine().getDHPublicKey(gyMpi);
+			return OtrCryptoEngine.getDHPublicKey(gyMpi);
 		} catch (Exception ex) {
 			throw new IOException();
 		}

--- a/src/main/java/net/java/otr4j/io/messages/SignatureMessage.java
+++ b/src/main/java/net/java/otr4j/io/messages/SignatureMessage.java
@@ -37,7 +37,7 @@ public class SignatureMessage extends AbstractEncodedMessage {
 
 	// Memthods.
 	public byte[] decrypt(byte[] key) throws OtrException {
-		return new OtrCryptoEngine().aesDecrypt(key, null, xEncrypted);
+		return OtrCryptoEngine.aesDecrypt(key, null, xEncrypted);
 	}
 
 	public boolean verify(byte[] key) throws OtrException {
@@ -49,7 +49,7 @@ public class SignatureMessage extends AbstractEncodedMessage {
 			throw new OtrException(e);
 		}
 
-		byte[] xEncryptedMAC = new OtrCryptoEngine().sha256Hmac160(
+		byte[] xEncryptedMAC = OtrCryptoEngine.sha256Hmac160(
 				xbEncrypted, key);
 		// Verify signature.
 		return Arrays.equals(this.xEncryptedMAC, xEncryptedMAC);

--- a/src/main/java/net/java/otr4j/session/AuthContext.java
+++ b/src/main/java/net/java/otr4j/session/AuthContext.java
@@ -122,21 +122,20 @@ public class AuthContext {
                         getLocalLongTermKeyPair().getPublic(),
                         getLocalDHKeyPairID());
 
-                OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
-                byte[] mhash = otrCryptoEngine.sha256Hmac(SerializationUtils
+                byte[] mhash = OtrCryptoEngine.sha256Hmac(SerializationUtils
                         .toByteArray(m), getM1());
-                byte[] signature = otrCryptoEngine.sign(mhash,
+                byte[] signature = OtrCryptoEngine.sign(mhash,
                         getLocalLongTermKeyPair().getPrivate());
 
                 SignatureX mysteriousX = new SignatureX(
                         getLocalLongTermKeyPair().getPublic(),
                         getLocalDHKeyPairID(), signature);
-                byte[] xEncrypted = otrCryptoEngine.aesEncrypt(getC(), null,
+                byte[] xEncrypted = OtrCryptoEngine.aesEncrypt(getC(), null,
                         SerializationUtils.toByteArray(mysteriousX));
 
                 byte[] tmp = SerializationUtils.writeData(xEncrypted);
 
-                byte[] xEncryptedHash = otrCryptoEngine.sha256Hmac160(tmp, getM2());
+                byte[] xEncryptedHash = OtrCryptoEngine.sha256Hmac160(tmp, getM2());
                 RevealSignatureMessage revealSignatureMessage =
                         new RevealSignatureMessage(getSession().getProtocolVersion(),
                                 xEncrypted, xEncryptedHash, getR());
@@ -156,15 +155,14 @@ public class AuthContext {
                     getLocalLongTermKeyPair().getPublic(),
                     getLocalDHKeyPairID());
 
-            OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
             byte[] mhash;
             try {
-                mhash = otrCryptoEngine.sha256Hmac(SerializationUtils.toByteArray(m), getM1p());
+                mhash = OtrCryptoEngine.sha256Hmac(SerializationUtils.toByteArray(m), getM1p());
             } catch (IOException e) {
                 throw new OtrException(e);
             }
 
-            byte[] signature = otrCryptoEngine.sign(mhash,
+            byte[] signature = OtrCryptoEngine.sign(mhash,
                     getLocalLongTermKeyPair().getPrivate());
 
             SignatureX mysteriousX = new SignatureX(getLocalLongTermKeyPair()
@@ -172,10 +170,10 @@ public class AuthContext {
 
             byte[] xEncrypted;
             try {
-                xEncrypted = otrCryptoEngine.aesEncrypt(getCp(), null,
+                xEncrypted = OtrCryptoEngine.aesEncrypt(getCp(), null,
                         SerializationUtils.toByteArray(mysteriousX));
                 byte[] tmp = SerializationUtils.writeData(xEncrypted);
-                byte[] xEncryptedHash = otrCryptoEngine.sha256Hmac160(tmp, getM2p());
+                byte[] xEncryptedHash = OtrCryptoEngine.sha256Hmac160(tmp, getM2p());
                 SignatureMessage signatureMessage =
                         new SignatureMessage(getSession().getProtocolVersion(), xEncrypted,
                                 xEncryptedHash);
@@ -277,7 +275,7 @@ public class AuthContext {
 
     public KeyPair getLocalDHKeyPair() throws OtrException {
         if (localDHKeyPair == null) {
-            localDHKeyPair = new OtrCryptoEngine().generateDHKeyPair();
+            localDHKeyPair = OtrCryptoEngine.generateDHKeyPair();
             logger.finest("Generated local D-H key pair.");
         }
         return localDHKeyPair;
@@ -289,8 +287,7 @@ public class AuthContext {
 
     private byte[] getLocalDHPublicKeyHash() throws OtrException {
         if (localDHPublicKeyHash == null) {
-            localDHPublicKeyHash = new OtrCryptoEngine()
-                    .sha256Hash(getLocalDHPublicKeyBytes());
+            localDHPublicKeyHash = OtrCryptoEngine.sha256Hash(getLocalDHPublicKeyBytes());
             logger.finest("Hashed local D-H public key.");
         }
         return localDHPublicKeyHash;
@@ -298,7 +295,7 @@ public class AuthContext {
 
     private byte[] getLocalDHPublicKeyEncrypted() throws OtrException {
         if (localDHPublicKeyEncrypted == null) {
-            localDHPublicKeyEncrypted = new OtrCryptoEngine().aesEncrypt(
+            localDHPublicKeyEncrypted = OtrCryptoEngine.aesEncrypt(
                     getR(), null, getLocalDHPublicKeyBytes());
             logger.finest("Encrypted our D-H public key.");
         }
@@ -307,7 +304,7 @@ public class AuthContext {
 
     public BigInteger getS() throws OtrException {
         if (s == null) {
-            s = new OtrCryptoEngine().generateSecret(this
+            s = OtrCryptoEngine.generateSecret(this
                     .getLocalDHKeyPair().getPrivate(), this
                     .getRemoteDHPublicKey());
             logger.finest("Generated shared secret.");
@@ -413,7 +410,7 @@ public class AuthContext {
         buff.put(b);
         buff.put(secbytes);
         byte[] sdata = buff.array();
-        return new OtrCryptoEngine().sha256Hash(sdata);
+        return OtrCryptoEngine.sha256Hash(sdata);
     }
 
     private byte[] getLocalDHPublicKeyBytes() throws OtrException {
@@ -490,16 +487,15 @@ public class AuthContext {
                 SignatureM remoteM = new SignatureM(this.getRemoteDHPublicKey(),
                         (DHPublicKey) this.getLocalDHKeyPair().getPublic(),
                         remoteLongTermPublicKey, remoteX.dhKeyID);
-                OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
                 // Verify signature.
                 byte[] signature;
                 try {
-                    signature = otrCryptoEngine.sha256Hmac(SerializationUtils
+                    signature = OtrCryptoEngine.sha256Hmac(SerializationUtils
                             .toByteArray(remoteM), this.getM1p());
                 } catch (IOException e) {
                     throw new OtrException(e);
                 }
-                if (!otrCryptoEngine.verify(signature, remoteLongTermPublicKey,
+                if (!OtrCryptoEngine.verify(signature, remoteLongTermPublicKey,
                         remoteX.signature)) {
                     logger.finest("Signature verification failed.");
                     return;
@@ -552,13 +548,12 @@ public class AuthContext {
                 // send
                 // it as a Data Message.
 
-                OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
                 // Uses r to decrypt the value of gx sent earlier
-                byte[] remoteDHPublicKeyDecrypted = otrCryptoEngine.aesDecrypt(
+                byte[] remoteDHPublicKeyDecrypted = OtrCryptoEngine.aesDecrypt(
                         m.revealedKey, null, this.getRemoteDHPublicKeyEncrypted());
 
                 // Verifies that HASH(gx) matches the value sent earlier
-                byte[] remoteDHPublicKeyHash = otrCryptoEngine
+                byte[] remoteDHPublicKeyHash = OtrCryptoEngine
                         .sha256Hash(remoteDHPublicKeyDecrypted);
                 if (!Arrays.equals(remoteDHPublicKeyHash, this
                         .getRemoteDHPublicKeyHash())) {
@@ -576,7 +571,7 @@ public class AuthContext {
                     throw new OtrException(e);
                 }
 
-                this.setRemoteDHPublicKey(otrCryptoEngine
+                this.setRemoteDHPublicKey(OtrCryptoEngine
                         .getDHPublicKey(remoteDHPublicKeyMpi));
 
                 // Verify received Data.
@@ -603,13 +598,13 @@ public class AuthContext {
                 // Verify signature.
                 byte[] signature;
                 try {
-                    signature = otrCryptoEngine.sha256Hmac(SerializationUtils
+                    signature = OtrCryptoEngine.sha256Hmac(SerializationUtils
                             .toByteArray(remoteM), this.getM1());
                 } catch (IOException e) {
                     throw new OtrException(e);
                 }
 
-                if (!otrCryptoEngine.verify(signature, remoteLongTermPublicKey,
+                if (!OtrCryptoEngine.verify(signature, remoteLongTermPublicKey,
                         remoteX.signature)) {
                     logger.finest("Signature verification failed.");
                     return;

--- a/src/main/java/net/java/otr4j/session/OtrSm.java
+++ b/src/main/java/net/java/otr4j/session/OtrSm.java
@@ -99,8 +99,7 @@ public class OtrSm {
 		byte[] their_fp;
 		PublicKey remotePublicKey = session.getRemotePublicKey();
 		try {
-			their_fp = new OtrCryptoEngine()
-					.getFingerprintRaw(remotePublicKey);
+			their_fp = OtrCryptoEngine.getFingerprintRaw(remotePublicKey);
 		} catch (OtrCryptoException e) {
 			throw new OtrException(e);
 		}
@@ -181,7 +180,7 @@ public class OtrSm {
 	public String getFingerprint() {
 		PublicKey pubKey = session.getRemotePublicKey();
 		try {
-			return new OtrCryptoEngine().getFingerprint(pubKey);
+			return OtrCryptoEngine.getFingerprint(pubKey);
         } catch (OtrCryptoException e) {
             e.printStackTrace();
         }

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -229,7 +229,7 @@ public class Session {
                 SessionKeys.Previous);
         sess2.setLocalPair(sess4.getLocalPair(), sess4.getLocalKeyID());
 
-        KeyPair newPair = new OtrCryptoEngine().generateDHKeyPair();
+        KeyPair newPair = OtrCryptoEngine.generateDHKeyPair();
         sess3.setLocalPair(newPair, sess3.getLocalKeyID() + 1);
         sess4.setLocalPair(newPair, sess4.getLocalKeyID() + 1);
     }
@@ -263,7 +263,7 @@ public class Session {
                     current.setS(auth.getS());
                 }
 
-                KeyPair nextDH = new OtrCryptoEngine().generateDHKeyPair();
+                KeyPair nextDH = OtrCryptoEngine.generateDHKeyPair();
                 for (int i = 0; i < this.getSessionKeys()[1].length; i++) {
                     SessionKeys current = getSessionKeysByIndex(1, i);
                     current.setRemoteDHPublicKey(auth.getRemoteDHPublicKey(), 1);
@@ -578,9 +578,7 @@ public class Session {
                     throw new OtrException(e);
                 }
 
-                OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
-
-                byte[] computedMAC = otrCryptoEngine.sha1Hmac(serializedT,
+                byte[] computedMAC = OtrCryptoEngine.sha1Hmac(serializedT,
                         matchingKeys.getReceivingMACKey(),
                         SerializationConstants.TYPE_LEN_MAC);
                 if (!Arrays.equals(computedMAC, data.mac)) {
@@ -598,7 +596,7 @@ public class Session {
 
                 matchingKeys.setReceivingCtr(data.ctr);
 
-                byte[] dmc = otrCryptoEngine.aesDecrypt(matchingKeys
+                byte[] dmc = OtrCryptoEngine.aesDecrypt(matchingKeys
                         .getReceivingAESKey(), matchingKeys.getReceivingCtr(),
                         data.encryptedMessage);
                 String decryptedMsgContent;
@@ -914,13 +912,11 @@ public class Session {
                     }
                 }
 
-                OtrCryptoEngine otrCryptoEngine = new OtrCryptoEngine();
-
                 byte[] data = out.toByteArray();
                 // Encrypt message.
                 logger.finest("Encrypting message with keyids (localKeyID, remoteKeyID) = ("
                         + senderKeyID + ", " + receipientKeyID + ")");
-                byte[] encryptedMsg = otrCryptoEngine.aesEncrypt(encryptionKeys
+                byte[] encryptedMsg = OtrCryptoEngine.aesEncrypt(encryptionKeys
                         .getSendingAESKey(), ctr, data);
 
                 // Get most recent keys to get the next D-H public key.
@@ -945,7 +941,7 @@ public class Session {
                     throw new OtrException(e);
                 }
 
-                byte[] mac = otrCryptoEngine.sha1Hmac(serializedT, sendingMACKey,
+                byte[] mac = OtrCryptoEngine.sha1Hmac(serializedT, sendingMACKey,
                         SerializationConstants.TYPE_LEN_MAC);
 
                 // Get old MAC keys to be revealed.

--- a/src/main/java/net/java/otr4j/session/SessionKeys.java
+++ b/src/main/java/net/java/otr4j/session/SessionKeys.java
@@ -125,7 +125,7 @@ public class SessionKeys {
             ByteBuffer buff = ByteBuffer.allocate(len);
             buff.put(b);
             buff.put(secbytes);
-            byte[] result = new OtrCryptoEngine().sha1Hash(buff.array());
+            byte[] result = OtrCryptoEngine.sha1Hash(buff.array());
             return result;
         } catch (Exception e) {
             throw new OtrException(e);
@@ -173,15 +173,14 @@ public class SessionKeys {
         if (sendingMACKey != null)
             return sendingMACKey;
 
-        sendingMACKey = new OtrCryptoEngine().sha1Hash(getSendingAESKey());
+        sendingMACKey = OtrCryptoEngine.sha1Hash(getSendingAESKey());
         logger.finest("Calculated sending MAC key.");
         return sendingMACKey;
     }
 
     public byte[] getReceivingMACKey() throws OtrException {
         if (receivingMACKey == null) {
-            receivingMACKey = new OtrCryptoEngine()
-                    .sha1Hash(getReceivingAESKey());
+            receivingMACKey = OtrCryptoEngine.sha1Hash(getReceivingAESKey());
             logger.finest("Calculated receiving AES key.");
         }
         return receivingMACKey;
@@ -189,7 +188,7 @@ public class SessionKeys {
 
     private BigInteger getS() throws OtrException {
         if (s == null) {
-            s = new OtrCryptoEngine().generateSecret(getLocalPair()
+            s = OtrCryptoEngine.generateSecret(getLocalPair()
                     .getPrivate(), getRemoteKey());
             logger.finest("Calculating shared secret S.");
         }

--- a/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
+++ b/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
@@ -20,8 +20,8 @@ import net.java.otr4j.crypto.SM.SMState;
 import net.java.otr4j.io.OtrOutputStream;
 import net.java.otr4j.io.SerializationUtils;
 
-public class OtrSm {
-    
+public class SmpTlvHandler {
+
 	private SMState smstate;
     private OtrEngineHost engineHost;
 	private Session session;
@@ -32,7 +32,7 @@ public class OtrSm {
 	 * @param session The session reference.
 	 * @param engineHost The host where we can present messages or ask for the shared secret.
 	 */
-	public OtrSm(Session session, OtrEngineHost engineHost) {
+	public SmpTlvHandler(Session session, OtrEngineHost engineHost) {
 		this.session = session;
 		this.engineHost = engineHost;
 		reset();
@@ -72,7 +72,7 @@ public class OtrSm {
 
 	/**
 	 *  Respond to or initiate an SMP negotiation
-	 *  
+	 *
 	 *  @param question
 	 *  	The question to present to the peer, if initiating.
 	 *  	May be <code>null</code> for no question.
@@ -80,7 +80,7 @@ public class OtrSm {
 	 *      in order to clarify whether this is shared secret verification.
 	 *  @param secret The secret.
 	 *  @param initiating Whether we are initiating or responding to an initial request.
-	 *  
+	 *
 	 *  @return TLVs to send to the peer
      *  @throws OtrException MVN_PASS_JAVADOC_INSPECTION
 	 */
@@ -123,7 +123,7 @@ public class OtrSm {
 			System.arraycopy(our_fp, 0, combined_buf, 21, 20);
 		}
 		System.arraycopy(sessionId, 0, combined_buf, 41, sessionId.length);
-		System.arraycopy(bytes, 0, 
+		System.arraycopy(bytes, 0,
 				combined_buf, 41 + sessionId.length, bytes.length);
 
 		MessageDigest sha256;
@@ -145,7 +145,7 @@ public class OtrSm {
 			throw new OtrException(ex);
 		}
 
-		// If we've got a question, attach it to the smpmsg 
+		// If we've got a question, attach it to the smpmsg
 		if (question != null && initiating){
 			bytes = question.getBytes(SerializationUtils.UTF8);
 			byte[] qsmpmsg = new byte[bytes.length + 1 + smpmsg.length];
@@ -154,7 +154,7 @@ public class OtrSm {
 			smpmsg = qsmpmsg;
 		}
 
-		TLV sendtlv = new TLV(initiating? 
+		TLV sendtlv = new TLV(initiating?
 				(question != null ? TLV.SMP1Q:TLV.SMP1) : TLV.SMP2, smpmsg);
 		smstate.nextExpected = initiating? SM.EXPECT2 : SM.EXPECT3;
 		smstate.approved = initiating || question == null;
@@ -163,7 +163,7 @@ public class OtrSm {
 
 	/**
 	 *  Create an abort TLV and reset our state.
-	 *  
+	 *
 	 *  @return TLVs to send to the peer
      *  @throws OtrException MVN_PASS_JAVADOC_INSPECTION
 	 */

--- a/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
+++ b/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
@@ -32,9 +32,9 @@ public class SmpTlvHandler {
 	 * @param session The session reference.
 	 * @param engineHost The host where we can present messages or ask for the shared secret.
 	 */
-	public SmpTlvHandler(Session session, OtrEngineHost engineHost) {
+	public SmpTlvHandler(Session session) {
 		this.session = session;
-		this.engineHost = engineHost;
+		this.engineHost = session.getHost();
 		reset();
 	}
 

--- a/src/test/java/net/java/otr4j/io/IOTest.java
+++ b/src/test/java/net/java/otr4j/io/IOTest.java
@@ -93,7 +93,7 @@ public class IOTest {
 	@Test
 	public void testIOBigInt() throws Exception {
 
-		KeyPair pair = new OtrCryptoEngine().generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
 		BigInteger source = ((DHPublicKey) pair.getPublic()).getY();
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -119,7 +119,7 @@ public class IOTest {
 
 	@Test
 	public void testIODHPublicKey() throws Exception {
-		KeyPair pair = new OtrCryptoEngine().generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
 
 		DHPublicKey source = (DHPublicKey) pair.getPublic();
 
@@ -146,7 +146,7 @@ public class IOTest {
 
 	@Test
 	public void testIODHKeyMessage() throws Exception {
-		KeyPair pair = new OtrCryptoEngine().generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
 
 		DHKeyMessage source = new DHKeyMessage(OTRv.THREE, (DHPublicKey) pair
 				.getPublic());

--- a/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
+++ b/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
@@ -337,8 +337,7 @@ public class DummyClient {
 
 		public byte[] getLocalFingerprintRaw(SessionID sessionID) {
 			try {
-				return new OtrCryptoEngine()
-						.getFingerprintRaw(getLocalKeyPair(sessionID)
+				return OtrCryptoEngine.getFingerprintRaw(getLocalKeyPair(sessionID)
 								.getPublic());
 			} catch (OtrCryptoException e) {
 				e.printStackTrace();


### PR DESCRIPTION
This is a collection of relatively minor changes to clean up the code a bit, and set a pattern to be used for handling future TLVs.  I've got the HTTP Data `REQUEST` and `RESPOND` TLVs working, but not yet ready for submission.  The idea is to only instantiate the TLV handler when it is used.  Otherwise, as we add support for more TLVs, like TLV8 and OTRDATA, then creating a `Session` will also create quite a bit of state related to TLV handling that mostly will never be used.
