### PR TITLE
Unicode tests for message body

### DIFF
--- a/src/test/java/net/java/otr4j/session/SessionTest.java
+++ b/src/test/java/net/java/otr4j/session/SessionTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import net.java.otr4j.OtrPolicy;
+import net.java.otr4j.test.TestStrings;
 import net.java.otr4j.test.dummyclient.DummyClient;
 import net.java.otr4j.test.dummyclient.PriorityServer;
 import net.java.otr4j.test.dummyclient.ProcessedTestMessage;
@@ -40,13 +41,7 @@ public class SessionTest {
         bob2.connect(server);
         bob3.connect(server);
 
-        bob1.send(
-                alice.getAccount(),
-                "<p>?OTRv23?\n"
-                        +
-                        "<span style=\"font-weight: bold;\">Bob@Wonderland/</span> has requested an <a href=\"http://otr.cypherpunks.ca/\">Off-the-Record private conversation</a>. However, you do not have a plugin to support that.\n"
-                        +
-                        "See <a href=\"http://otr.cypherpunks.ca/\">http://otr.cypherpunks.ca/</a> for more information.</p>");
+        bob1.send(alice.getAccount(), TestStrings.otrQuery);
 
         alice.pollReceivedMessage(); // Query
         bob1.pollReceivedMessage(); // DH-Commit
@@ -66,7 +61,7 @@ public class SessionTest {
         assertEquals("Received message is different from the sent message.",
                 msg, bob1.pollReceivedMessage().getContent());
 
-        bob2.send(alice.getAccount(), msg = "?OTRv23? Message from another client !");
+        bob2.send(alice.getAccount(), msg = TestStrings.anotherOtrQuery);
 
         alice.pollReceivedMessage();
         bob2.pollReceivedMessage();
@@ -81,7 +76,7 @@ public class SessionTest {
         assertEquals("Received message is different from the sent message.",
                 msg, alice.pollReceivedMessage().getContent());
 
-        bob3.send(alice.getAccount(), msg = "?OTRv23? Another message from another client !!");
+        bob3.send(alice.getAccount(), msg = TestStrings.yetAnotherOtrQuery);
         alice.pollReceivedMessage();
         bob3.pollReceivedMessage();
         alice.pollReceivedMessage();
@@ -136,13 +131,7 @@ public class SessionTest {
         DummyClient alice = convo[0];
         DummyClient bob = convo[1];
 
-        bob.send(
-                alice.getAccount(),
-                "<p>?OTRv23?\n"
-                        +
-                        "<span style=\"font-weight: bold;\">Bob@Wonderland/</span> has requested an <a href=\"http://otr.cypherpunks.ca/\">Off-the-Record private conversation</a>. However, you do not have a plugin to support that.\n"
-                        +
-                        "See <a href=\"http://otr.cypherpunks.ca/\">http://otr.cypherpunks.ca/</a> for more information.</p>");
+        bob.send(alice.getAccount(), TestStrings.otrQuery);
 
         alice.pollReceivedMessage(); // Query
         bob.pollReceivedMessage(); // DH-Commit

--- a/src/test/java/net/java/otr4j/test/SMPTest.java
+++ b/src/test/java/net/java/otr4j/test/SMPTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import net.java.otr4j.OtrException;
+import net.java.otr4j.io.SerializationUtils;
 import net.java.otr4j.session.Session;
 import net.java.otr4j.test.dummyclient.DummyClient;
 
@@ -113,6 +114,16 @@ public class SMPTest {
         // wait for the password prompt that is triggered by:
         // OtrEngineHost.askForSecret()
         assertTrue(bobLock.await(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // make sure that the SMP question arrived intact
+        String bobReceivedQuestion = bob.getSmpQuestion(bobSession.getSessionID());
+        assertEquals(question, bobReceivedQuestion);
+        if (question != null) {
+            assertEquals(question.length(), bobReceivedQuestion.length());
+            assertEquals(question.getBytes().length, bobReceivedQuestion.getBytes().length);
+            assertEquals(question.getBytes(SerializationUtils.UTF8).length,
+                    bobReceivedQuestion.getBytes(SerializationUtils.UTF8).length);
+        }
 
         bobSession.respondSmp(question, bobPassword);
         assertTrue(aliceSession.isSmpInProgress());

--- a/src/test/java/net/java/otr4j/test/SMPTest.java
+++ b/src/test/java/net/java/otr4j/test/SMPTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -36,36 +36,16 @@ public class SMPTest {
         this.snippet = snippet;
     }
 
-    // TODO these currently cause an Exception when used as question:
-    // "nullshere:\0\0andhere:\0",
-    // "tabbackslashT\t",
-    // "backslashR\r",
-    // "NEWLINE\n",
     @Parameters
     public static Collection<Object[]> data() {
-        return Arrays
-                .asList(new Object[][] {
-                        { "plainAscii" },
-                        { "" },
-                        { "བོད་རིགས་ཀྱི་བོད་སྐད་བརྗོད་པ་དང་ "
-                                + "བོད་རིགས་མང་ཆེ་བ་ནི་ནང་ཆོས་བྱེད་པ་དང་" },
-                        { "تبتی قوم (Tibetan people)" },
-                        { "Учените твърдят, че тибетците нямат" },
-                        { "Câung-cŭk (藏族, Câung-ngṳ̄: བོད་པ་)" },
-                        { "チベット系民族（チベットけいみんぞく）" },
-                        { "原始汉人与原始藏缅人约在公元前4000年左右分开。" },
-                        { "Տիբեթացիներ (ինքնանվանումը՝ պյոբա)," },
-                        { "... Gezginci olarak" },
-                        { "شْتَن Xotan" },
-                        { "Tibeťané jsou" },
-                        { "ئاچاڭ- تىبەت مىللىتى" },
-                        { "Miscellaneous Symbols and Pictographs[1][2]"
-                                + "Official Unicode Consortium code chart (PDF)" },
-                        { "Royal Thai (ราชาศัพท์)" }, { "טיילאנדיש123 (ภาษาไทย)" },
-                        { "ជើងអក្សរ cheung âksâr" }, { "중화인민공화국에서는 기본적으로 한족은 " },
-                        { "पाठ्यांशः अत्र उपलभ्यतेसर्जनसामान्यलक्षणम्/Share-" },
-                        { "திபெத்துக்கு வெகள்" },
-                        { "អក្សរសាស្រ្តខែ្មរមានប្រវ៌ត្តជាងពីរពាន់ឆ្នាំមកហើយ " }, });
+        // this crazy format is needed by JUnit:
+        // https://github.com/junit-team/junit/wiki/Parameterized-tests
+        ArrayList<Object[]> list = new ArrayList<Object[]>(TestStrings.unicodes.length);
+        for (String string : TestStrings.unicodes)
+            list.add(new Object[] {
+                    string
+            });
+        return list;
     }
 
     private static class SMPTestResult {

--- a/src/test/java/net/java/otr4j/test/SMPTest.java
+++ b/src/test/java/net/java/otr4j/test/SMPTest.java
@@ -28,7 +28,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class SMPTest {
 
-    private static final int DEFAULT_TIMEOUT_MS = 2000;
+    private static final int DEFAULT_TIMEOUT_MS = 10000;
     private static final String SIMPLE_PASSWORD = "MATCH";
     private final String snippet;
 

--- a/src/test/java/net/java/otr4j/test/TestStrings.java
+++ b/src/test/java/net/java/otr4j/test/TestStrings.java
@@ -1,0 +1,34 @@
+
+package net.java.otr4j.test;
+
+public class TestStrings {
+
+    // TODO these currently cause an Exception when used as SMP question:
+    // "nullshere:\0\0andhere:\0",
+    // "tabbackslashT\t",
+    // "backslashR\r",
+    // "NEWLINE\n",
+    public static String[] unicodes = {
+            "plainAscii",
+            "",
+            "བོད་རིགས་ཀྱི་བོད་སྐད་བརྗོད་པ་དང་ བོད་རིགས་མང་ཆེ་བ་ནི་ནང་ཆོས་བྱེད་པ་དང་",
+            "تبتی قوم (Tibetan people)",
+            "Учените твърдят, че тибетците нямат",
+            "Câung-cŭk (藏族, Câung-ngṳ̄: བོད་པ་)",
+            "チベット系民族（チベットけいみんぞく）",
+            "原始汉人与原始藏缅人约在公元前4000年左右分开。",
+            "Տիբեթացիներ (ինքնանվանումը՝ պյոբա),",
+            "... Gezginci olarak",
+            "شْتَن Xotan",
+            "Tibeťané jsou",
+            "ئاچاڭ- تىبەت مىللىتى",
+            "Miscellaneous Symbols and Pictographs[1][2] Official Unicode Consortium code chart (PDF)",
+            "Royal Thai (ราชาศัพท์)",
+            "טיילאנדיש123 (ภาษาไทย)",
+            "ជើងអក្សរ cheung âksâr",
+            "중화인민공화국에서는 기본적으로 한족은 ",
+            "पाठ्यांशः अत्र उपलभ्यतेसर्जनसामान्यलक्षणम्/Share-",
+            "திபெத்துக்கு வெகள்",
+            "អក្សរសាស្រ្តខែ្មរមានប្រវ៌ត្តជាងពីរពាន់ឆ្នាំមកហើយ ",
+    };
+}

--- a/src/test/java/net/java/otr4j/test/TestStrings.java
+++ b/src/test/java/net/java/otr4j/test/TestStrings.java
@@ -31,4 +31,10 @@ public class TestStrings {
             "திபெத்துக்கு வெகள்",
             "អក្សរសាស្រ្តខែ្មរមានប្រវ៌ត្តជាងពីរពាន់ឆ្នាំមកហើយ ",
     };
+
+    public static final String otrQuery = "<p>?OTRv23?\n"
+            + "<span style=\"font-weight: bold;\">Bob@Wonderland/</span> has requested an <a href=\"http://otr.cypherpunks.ca/\">Off-the-Record private conversation</a>. However, you do not have a plugin to support that.\n"
+            + "See <a href=\"http://otr.cypherpunks.ca/\">http://otr.cypherpunks.ca/</a> for more information.</p>";
+    public static final String anotherOtrQuery = "?OTRv23? Message from another client !";
+    public static final String yetAnotherOtrQuery = "?OTRv23? Another message from another client !!";
 }

--- a/src/test/java/net/java/otr4j/test/UnicodeMessageTest.java
+++ b/src/test/java/net/java/otr4j/test/UnicodeMessageTest.java
@@ -1,0 +1,97 @@
+
+package net.java.otr4j.test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import net.java.otr4j.session.SessionStatus;
+import net.java.otr4j.test.dummyclient.DummyClient;
+
+import org.junit.Test;
+
+/**
+ * Test unicode handling in the message body
+ *
+ * @author Hans-Christoph Steiner
+ */
+public class UnicodeMessageTest {
+
+    @Test
+    public void testForcedStart() throws Exception {
+        DummyClient[] convo = DummyClient.getConversation();
+        DummyClient alice = convo[0];
+        DummyClient bob = convo[1];
+
+        DummyClient.forceStartOtr(alice, bob);
+
+        String msg;
+        for (String test : TestStrings.unicodes) {
+            assertEquals("The session is not encrypted.", SessionStatus.ENCRYPTED,
+                    bob.getSession().getSessionStatus());
+            assertEquals("The session is not encrypted.", SessionStatus.ENCRYPTED,
+                    alice.getSession().getSessionStatus());
+
+            alice.send(bob.getAccount(), msg = "A->B: " + test);
+            assertThat("Message has been transferred unencrypted.", alice
+                    .getConnection().getSentMessage(), not(equalTo(msg)));
+            assertEquals("Received message is different from the sent message.",
+                    msg, bob.pollReceivedMessage().getContent());
+
+            bob.send(alice.getAccount(), msg = test + "B->A");
+            assertThat("Message has been transferred unencrypted.", bob
+                    .getConnection().getSentMessage(), not(equalTo(msg)));
+            assertEquals("Received message is different from the sent message.",
+                    msg, alice.pollReceivedMessage().getContent());
+        }
+
+        bob.exit();
+        alice.exit();
+    }
+
+    @Test
+    public void testPlaintext() throws Exception {
+        DummyClient[] convo = DummyClient.getConversation();
+        DummyClient alice = convo[0];
+        DummyClient bob = convo[1];
+
+        String msg;
+        for (String test : TestStrings.unicodes) {
+            // first round, mark the message with an ASCII tag
+            alice.send(bob.getAccount(), msg = "A->B: " + test);
+            assertEquals("Message has been altered (but it shouldn't).", msg,
+                    alice.getConnection().getSentMessage());
+            assertEquals("Received message is different from the sent message.",
+                    msg, bob.pollReceivedMessage().getContent());
+
+            bob.send(alice.getAccount(), msg = test + "B->A");
+            assertEquals("Message has been altered (but it shouldn't).", msg,
+                    bob.getConnection().getSentMessage());
+            assertEquals("Received message is different from the sent message.",
+                    msg, alice.pollReceivedMessage().getContent());
+
+            // there should definitely be a OTR Session now
+            assertEquals("The session should not be encrypted.", SessionStatus.PLAINTEXT,
+                    bob.getSession().getSessionStatus());
+            assertEquals("The session should not be encrypted.", SessionStatus.PLAINTEXT,
+                    alice.getSession().getSessionStatus());
+
+            // second round, just send the same bit of unicode back and forth
+            alice.send(bob.getAccount(), msg = test);
+            assertEquals("Message has been altered (but it shouldn't).", msg,
+                    alice.getConnection().getSentMessage());
+            assertEquals("Received message is different from the sent message.",
+                    msg, bob.pollReceivedMessage().getContent());
+
+            bob.send(alice.getAccount(), msg = test);
+            assertEquals("Message has been altered (but it shouldn't).", msg,
+                    bob.getConnection().getSentMessage());
+            assertEquals("Received message is different from the sent message.",
+                    msg, alice.pollReceivedMessage().getContent());
+        }
+
+        bob.exit();
+        alice.exit();
+    }
+}

--- a/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
+++ b/src/test/java/net/java/otr4j/test/dummyclient/DummyClient.java
@@ -34,6 +34,7 @@ public class DummyClient {
 	private Connection connection;
 	private MessageProcessor processor;
 	private Queue<ProcessedTestMessage> processedMsgs = new LinkedList<ProcessedTestMessage>();
+	private HashMap<SessionID, String>smpQuestions = new HashMap<SessionID, String>();
 
     private CountDownLatch lock;
     private int verified = NOTSET;
@@ -167,6 +168,10 @@ public class DummyClient {
 		return connection;
 	}
 
+	public String getSmpQuestion(SessionID sessionId) {
+	    return smpQuestions.get(sessionId);
+	}
+
 	public ProcessedTestMessage pollReceivedMessage() {
 		synchronized (processedMsgs) {
 			ProcessedTestMessage m;
@@ -283,11 +288,13 @@ public class DummyClient {
 		public void smpError(SessionID sessionID, int tlvType, boolean cheated)
 				throws OtrException {
 			logger.severe("SM verification error with user: " + sessionID);
+			smpQuestions.remove(sessionID);
 		}
 
 		public void smpAborted(SessionID sessionID) throws OtrException {
 			logger.severe("SM verification has been aborted by user: "
 					+ sessionID);
+			smpQuestions.remove(sessionID);
 		}
 
 		public void finishedSessionMessage(SessionID sessionID, String msgText) throws OtrException {
@@ -349,6 +356,7 @@ public class DummyClient {
 		public void askForSecret(SessionID sessionID, InstanceTag receiverTag, String question) {
             logger.finer("Ask for secret from: " + sessionID
                     + ", instanceTag: " + receiverTag + ", question: " + question);
+            smpQuestions.put(sessionID, question);
             if (lock != null)
                 lock.countDown();
 		}


### PR DESCRIPTION
In reference to #46 I wrote some tests that put all sorts of Unicode text in the message body, for both unencrypted and encrypted messages.  It turns out that they work fine in these tests, so we still need to figure out what is up with the OTR packet that libotr is sending.
