### PR TITLE
Modified implementation to support instance tag values to maximum of 0xf...

### DIFF
--- a/src/main/java/net/java/otr4j/session/InstanceTag.java
+++ b/src/main/java/net/java/otr4j/session/InstanceTag.java
@@ -10,31 +10,49 @@ public class InstanceTag {
 
 	public static final int SMALLEST_VALUE = 0x00000100;
 
-	public static final int HIGHEST_VALUE = 0x11111111;
+	public static final int HIGHEST_VALUE = 0xffffffff;
 
-	public static final InstanceTag ZERO_TAG = new InstanceTag(0);
+	public static final InstanceTag ZERO_TAG = new InstanceTag(ZERO_VALUE);
 
-	public static final InstanceTag SMALLEST_TAG = new InstanceTag(0x00000100);
+	public static final InstanceTag SMALLEST_TAG = new InstanceTag(SMALLEST_VALUE);
 
-	public static final InstanceTag HIGHEST_TAG = new InstanceTag(0x11111111);
+	public static final InstanceTag HIGHEST_TAG = new InstanceTag(HIGHEST_VALUE);
 
+	/**
+	 * Range for valid instance tag values.
+	 * Corrected for existence of smallest value boundary.
+	 */
+	private static final long RANGE = 0xfffffeffL;
+
+	/**
+	 * Value of the instance tag instance.
+	 */
 	private final int value;
 
-	public static boolean isValidInstanceTag(int tagValue) {
-		return 	tagValue == 0 ||
-				(tagValue >= SMALLEST_VALUE && tagValue <= HIGHEST_VALUE);
+	public static boolean isValidInstanceTag(final int tagValue) {
+		return !(0 < tagValue && tagValue < SMALLEST_VALUE);
 	}
 
 	public InstanceTag() {
-		value = r.nextInt(HIGHEST_VALUE - SMALLEST_VALUE) + SMALLEST_VALUE;
+		final long val = (long)(r.nextDouble()*RANGE) + SMALLEST_VALUE;
+		// Because 0xffffffff is the maximum value for both the tag and
+		// the 32 bit integer range, we are able to cast to int without
+		// loss. The (decimal) interpretation changes, though, because
+		// Java's int interprets the last bit as the sign bit. This does
+		// not matter, however, since we do not need to do value
+		// comparisons / ordering. We only care about equal/not equal.
+		this.value = (int)val;
 	}
 
 	public int getValue() {
 		return value;
 	}
 
-	InstanceTag(int value)
-	{
+	InstanceTag(final int value) {
+		if (!isValidInstanceTag(value))
+		{
+			throw new IllegalArgumentException("Invalid tag value.");
+		}
 		this.value = value;
 	}
 

--- a/src/main/java/net/java/otr4j/session/InstanceTag.java
+++ b/src/main/java/net/java/otr4j/session/InstanceTag.java
@@ -8,8 +8,15 @@ public class InstanceTag {
 
 	public static final int ZERO_VALUE = 0;
 
+	/**
+	 * The smallest possible valid tag value.
+	 */
 	public static final int SMALLEST_VALUE = 0x00000100;
 
+	/**
+	 * The highest possible tag value.
+	 * Note that this is -1 in the decimal representation.
+	 */
 	public static final int HIGHEST_VALUE = 0xffffffff;
 
 	public static final InstanceTag ZERO_TAG = new InstanceTag(ZERO_VALUE);
@@ -30,6 +37,12 @@ public class InstanceTag {
 	private final int value;
 
 	public static boolean isValidInstanceTag(final int tagValue) {
+		// Note that the decimal representation of Java's int is always
+		// signed, that means that any value over 0x7fffffff will be
+		// interpreted as a negative value. So, instead we verify that
+		// the tag value is not in the "forbidden range".
+		// Other than the forbidden range, every possible value of the
+		// 32 bits of memory is acceptable.
 		return !(0 < tagValue && tagValue < SMALLEST_VALUE);
 	}
 
@@ -56,6 +69,7 @@ public class InstanceTag {
 		this.value = value;
 	}
 
+	@Override
 	public boolean equals(Object other) {
 		if (this == other)
 			return true;
@@ -67,6 +81,7 @@ public class InstanceTag {
 		return this.value == otherInstanceTag.getValue();
 	}
 
+	@Override
 	public int hashCode() {
 		return value;
 	}

--- a/src/test/java/net/java/otr4j/session/InstanceTagTest.java
+++ b/src/test/java/net/java/otr4j/session/InstanceTagTest.java
@@ -1,0 +1,74 @@
+package net.java.otr4j.session;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Danny van Heumen
+ */
+public class InstanceTagTest {
+
+    @Test
+    public void testConstructZeroTag() {
+        InstanceTag tag = new InstanceTag(0);
+        assertEquals(0, tag.getValue());
+    }
+
+    @Test
+    public void testConstructSmallestTag() {
+        InstanceTag tag = new InstanceTag(InstanceTag.SMALLEST_VALUE);
+        assertEquals(InstanceTag.SMALLEST_VALUE, tag.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testConstructTooSmallTagLowerBound() {
+        new InstanceTag(1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testConstructTooSmallTagUpperBound() {
+        new InstanceTag(255);
+    }
+
+    @Test
+    public void testConstructLargestTag() {
+        InstanceTag tag = new InstanceTag(InstanceTag.HIGHEST_VALUE);
+        // Make sure that value gets preserved as is.
+        assertEquals(0xffffffff, InstanceTag.HIGHEST_VALUE & tag.getValue());
+    }
+
+    @Test
+    public void testConstructSomeOtherLargeValue() {
+        InstanceTag tag = new InstanceTag(0xedcbafed);
+        // Just testing another arbitrary value in signed int's negative area.
+        assertEquals(0xedcbafed, 0xedcbafed & tag.getValue());
+    }
+
+    /**
+     * A quick check of the area in which the tag values are distributed.
+     * This thing isn't fool proof, but should work in almost all cases.
+     */
+    @Test
+    public void testConstructorRandomness() {
+        int[] distr = new int[1000];
+        InstanceTag tag;
+        int val;
+        long longval;
+        int idx;
+        for (int i = 0; i < 500000; i++) {
+            tag = new InstanceTag();
+            val = tag.getValue();
+            assertFalse("" + val, 0 <= val && val < InstanceTag.SMALLEST_VALUE);
+            // convert to long preserving bits (i.e. don't convert negative int to negative long
+            longval = val & 0xffffffffL;
+            idx = (int) ((double) (longval - 0x00000100L) / 0xfffffeffL * distr.length);
+            distr[idx]++;
+        }
+        for (int part : distr) {
+            assertTrue(part > 0);
+        }
+    }
+}


### PR DESCRIPTION
...fffffff, which is the maximum value allowed by OTRv3.

Additionally, added some tests to ensure that maximum value is honored
even though Java interprets these as negative values, as the last bit is
the sign bit for Java's signed int primitive.
Had to change to random value generation, since this was limited by an
int > 0 parameter.
