### PR TITLE
use java.security.SecureRandom to be sure

### DIFF
--- a/src/main/java/net/java/otr4j/session/AuthContext.java
+++ b/src/main/java/net/java/otr4j/session/AuthContext.java
@@ -12,8 +12,8 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.KeyPair;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.Vector;
 import java.util.logging.Logger;
 
@@ -60,6 +60,7 @@ public class AuthContext {
     // If the Session that this AuthContext belongs to is the 'master' session
     // then these parameters must be replicated to all slave session's auth
     // contexts.
+    SecureRandom secureRandom;
     byte[] r;
     KeyPair localDHKeyPair;
     byte[] localDHPublicKeyBytes;
@@ -231,10 +232,12 @@ public class AuthContext {
     }
 
     private byte[] getR() {
+        if (secureRandom == null)
+            secureRandom = new java.security.SecureRandom();
         if (r == null) {
             logger.finest("Picking random key r.");
             r = new byte[OtrCryptoEngine.AES_KEY_BYTE_LENGTH];
-            new Random().nextBytes(r);
+            secureRandom.nextBytes(r);
         }
         return r;
     }


### PR DESCRIPTION
OTR's `r` value should probably be a good random number.

This also switches instantiation of SecureRandom to when it is first used, rather than when the class is instantiated since SecureRandom is not always required.
