### PR TITLE
Updated InstanceTag that accepts double range ratio

### DIFF
--- a/src/main/java/net/java/otr4j/session/InstanceTag.java
+++ b/src/main/java/net/java/otr4j/session/InstanceTag.java
@@ -1,10 +1,8 @@
 package net.java.otr4j.session;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 public class InstanceTag {
-
-	private static final Random r = new Random();
 
 	public static final int ZERO_VALUE = 0;
 
@@ -46,8 +44,34 @@ public class InstanceTag {
 		return !(0 < tagValue && tagValue < SMALLEST_VALUE);
 	}
 
+	/**
+	 * The default constructor for Instance Tag.
+	 *
+	 * If you need to construct many instance tags, you should consider
+	 * using {@link #InstanceTag(double) } and your own instance of
+	 * SecureRandom to prevent the additional overhead of instantiating
+	 * SecureRandom.
+	 */
 	public InstanceTag() {
-		final long val = (long)(r.nextDouble()*RANGE) + SMALLEST_VALUE;
+		this(new SecureRandom().nextDouble());
+	}
+
+	/**
+	 * Instance Tag constructor.
+	 *
+	 * This version of the constructor is provided in order to provide an
+	 * "pre-generated" random double from which a valid random tag value is
+	 * derived.
+	 *
+	 * @param ratio The provided (random) double ratio that is used to
+	 * derive a tag value from the full range of valid tag values. The ratio
+	 * should be a value between 0 (inclusive) and 1 (exclusive).
+	 */
+	public InstanceTag(final double ratio) {
+		if (ratio < 0 || ratio >= 1) {
+			throw new IllegalArgumentException("ratio should be a value between 0 and 1");
+		}
+		final long val = (long)(ratio*RANGE) + SMALLEST_VALUE;
 		// Because 0xffffffff is the maximum value for both the tag and
 		// the 32 bit integer range, we are able to cast to int without
 		// loss. The (decimal) interpretation changes, though, because

--- a/src/test/java/net/java/otr4j/session/InstanceTagTest.java
+++ b/src/test/java/net/java/otr4j/session/InstanceTagTest.java
@@ -34,6 +34,31 @@ public class InstanceTagTest {
     }
 
     @Test
+    public void testConstructorRatioZero() {
+        InstanceTag tag = new InstanceTag(0d);
+        assertEquals(InstanceTag.SMALLEST_VALUE, tag.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testConstructorRatioNegativeRatio() {
+        new InstanceTag(-0.25d);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testConstructorRatioTooHigh() {
+        new InstanceTag(2d);
+    }
+
+    @Test
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testConstructorRatioValid() {
+        InstanceTag tag = new InstanceTag(0.25);
+        assertEquals(1073742015, tag.getValue());
+    }
+
+    @Test
     public void testConstructLargestTag() {
         InstanceTag tag = new InstanceTag(InstanceTag.HIGHEST_VALUE);
         // Make sure that value gets preserved as is.


### PR DESCRIPTION
An updated InstanceTag implementation that adds a new constructor. This constructor accepts a double value between 0 (inclusive) and 1 (exclusive). This new constructor allows one to get a double from a Random source and create an instance tag from that. By providing a value between 0 and 1, you automatically access the whole range of valid instance tag values.

In the current patch, this constructor is not yet in use. Next up is to lift the SecureRandom instance to Session, create it once and pass it on to any created InstanceTag and AuthContext, which both use SecureRandom. Currently, both classes instantiate SecureRandom upon first use, but we can now share the one instance. I'd like to view the Session instance as the "natural boundary" for sharing a single SecureRandom instance.
