### PR TITLE
Session-wide SecureRandom instance

### DIFF
--- a/src/main/java/net/java/otr4j/crypto/OtrCryptoEngine.java
+++ b/src/main/java/net/java/otr4j/crypto/OtrCryptoEngine.java
@@ -77,13 +77,13 @@ public class OtrCryptoEngine {
         // this class is never instantiated, it only has static methods
     }
 
-    public static KeyPair generateDHKeyPair() throws OtrCryptoException {
+    public static KeyPair generateDHKeyPair(final SecureRandom secureRandom) throws OtrCryptoException {
 
         // Generate a AsymmetricCipherKeyPair using BC.
         DHParameters dhParams = new DHParameters(MODULUS, GENERATOR, null,
                 DH_PRIVATE_KEY_MINIMUM_BIT_LENGTH);
         DHKeyGenerationParameters params = new DHKeyGenerationParameters(
-                new SecureRandom(), dhParams);
+                secureRandom, dhParams);
         DHKeyPairGenerator kpGen = new DHKeyPairGenerator();
 
         kpGen.init(params);

--- a/src/main/java/net/java/otr4j/crypto/SM.java
+++ b/src/main/java/net/java/otr4j/crypto/SM.java
@@ -742,24 +742,4 @@ public class SM {
 
 	    return;
 	}
-
-	// ***************************************************
-	// Session stuff - perhaps factor out
-	
-	public static void main(String[] args) throws SMException {
-		BigInteger res = SM.MODULUS_MINUS_2.subtract(SM.MODULUS_S).mod(SM.MODULUS_S);
-		String ss = Util.bytesToHexString(res.toByteArray());
-		System.out.println(ss);
-		
-		byte[] secret1 = "abcdef".getBytes(SerializationUtils.UTF8);
-		SMState a = new SMState();
-		SMState b = new SMState();
-		
-		byte[] msg1 = SM.step1(a, secret1);
-		SM.step2a(b, msg1, 123);
-		byte[] msg2 = SM.step2b(b, secret1);
-		byte[] msg3 = SM.step3(a, msg2);
-		byte[] msg4 = SM.step4(b, msg3);
-		SM.step5(a, msg4);
-	}
 }

--- a/src/main/java/net/java/otr4j/crypto/SM.java
+++ b/src/main/java/net/java/otr4j/crypto/SM.java
@@ -127,10 +127,10 @@ public class SM {
 	/**
      * Generate a random exponent
      *
+     * @param sr SecureRandom instance to use for random data
      * @return the generated random exponent.
      */
-	public static BigInteger randomExponent() {
-		SecureRandom sr = new SecureRandom();
+	public static BigInteger randomExponent(final SecureRandom sr) {
 		byte[] sb = new byte[MOD_LEN_BYTES];
 		sr.nextBytes(sb);
 		return new BigInteger(1, sb);
@@ -229,12 +229,13 @@ public class SM {
      * @param g the group generator
      * @param x the secret information
      * @param version the prefix to use for the hashing function
+     * @param sr SecureRandom instance
      * @return c and d.
 	 * @throws SMException when c and d could not be calculated
 	 */
-	public static BigInteger[] proofKnowLog(BigInteger g, BigInteger x, int version) throws SMException
+	public static BigInteger[] proofKnowLog(BigInteger g, BigInteger x, int version, SecureRandom sr) throws SMException
 	{
-	    BigInteger r = randomExponent();
+	    BigInteger r = randomExponent(sr);
 	    BigInteger temp = g.modPow(r, SM.MODULUS_S);
 	    BigInteger c = hash(version, temp, null);
 	    temp = x.multiply(c).mod(ORDER_S);
@@ -274,13 +275,14 @@ public class SM {
      * @param state MVN_PASS_JAVADOC_INSPECTION
      * @param r MVN_PASS_JAVADOC_INSPECTION
      * @param version MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
 	 */
-	public static BigInteger[] proofEqualCoords(SMState state, BigInteger r, int version) throws SMException
+	public static BigInteger[] proofEqualCoords(SMState state, BigInteger r, int version, SecureRandom sr) throws SMException
 	{
-	    BigInteger r1 = randomExponent();
-	    BigInteger r2 = randomExponent();
+	    BigInteger r1 = randomExponent(sr);
+	    BigInteger r2 = randomExponent(sr);
 
 	    /* Compute the value of c, as c = h(g3^r1, g1^r1 g2^r2) */
 	    BigInteger temp1 = state.g1.modPow(r1, MODULUS_S);
@@ -348,12 +350,13 @@ public class SM {
 	 * Proof of knowledge of logs with exponents being equal
      * @param state MVN_PASS_JAVADOC_INSPECTION
      * @param version MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
 	 */
-	public static BigInteger[] proofEqualLogs(SMState state, int version) throws SMException
+	public static BigInteger[] proofEqualLogs(SMState state, int version, SecureRandom sr) throws SMException
 	{
-	    BigInteger r = randomExponent();
+	    BigInteger r = randomExponent(sr);
 
 	    /* Compute the value of c, as c = h(g1^r, (Qa/Qb)^r) */
 	    BigInteger temp1 = state.g1.modPow(r, MODULUS_S);
@@ -416,13 +419,14 @@ public class SM {
 	 * [0] = g2a, Alice's half of DH exchange to determine g2
 	 * [1] = c2, [2] = d2, Alice's ZK proof of knowledge of g2a exponent
 	 * [3] = g3a, Alice's half of DH exchange to determine g3
-	 * [4] = c3, [5] = d3, Alice's ZK proof of knowledge of g3a exponent 
+	 * [4] = c3, [5] = d3, Alice's ZK proof of knowledge of g3a exponent
      * @param astate MVN_PASS_JAVADOC_INSPECTION
      * @param secret MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
      */
-	public static byte[] step1(SMState astate, byte[] secret) throws SMException
+	public static byte[] step1(SMState astate, byte[] secret, SecureRandom sr) throws SMException
 	{
 	    /* Initialize the sm state or update the secret */
 		//Util.checkBytes("secret", secret);
@@ -430,17 +434,17 @@ public class SM {
 
 	    astate.secret = secret_mpi;
 	    astate.receivedQuestion = 0;
-	    astate.x2 = randomExponent();
-	    astate.x3 = randomExponent();
+	    astate.x2 = randomExponent(sr);
+	    astate.x3 = randomExponent(sr);
 
 	    BigInteger[] msg1 = new BigInteger[6];
 	    msg1[0] = astate.g1.modPow(astate.x2, MODULUS_S);
-	    BigInteger[] res = proofKnowLog(astate.g1, astate.x2, 1);
+	    BigInteger[] res = proofKnowLog(astate.g1, astate.x2, 1, sr);
 	    msg1[1]=res[0];
 	    msg1[2]=res[1];
 	    
 	    msg1[3] = astate.g1.modPow(astate.x3, MODULUS_S);
-	    res = proofKnowLog(astate.g1, astate.x3, 2);
+	    res = proofKnowLog(astate.g1, astate.x3, 2, sr);
 	    msg1[4]=res[0];
 	    msg1[5]=res[1];
 
@@ -456,9 +460,10 @@ public class SM {
      * @param bstate MVN_PASS_JAVADOC_INSPECTION
      * @param input MVN_PASS_JAVADOC_INSPECTION
      * @param received_question MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
      */
-	public static void step2a(SMState bstate, byte[] input, int received_question) throws SMException
+	public static void step2a(SMState bstate, byte[] input, int received_question, SecureRandom sr) throws SMException
 	{
 
 	    /* Initialize the sm state if needed */
@@ -485,8 +490,8 @@ public class SM {
 
 	    /* Create Bob's half of the generators g2 and g3 */
 	    
-	    bstate.x2 = randomExponent();
-	    bstate.x3 = randomExponent();
+	    bstate.x2 = randomExponent(sr);
+	    bstate.x3 = randomExponent(sr);
 
 	    /* Combine the two halves from Bob and Alice and determine g2 and g3 */
 	    bstate.g2= msg1[0].modPow(bstate.x2, MODULUS_S);
@@ -509,10 +514,11 @@ public class SM {
 	 * [8] = cp, [9] = d5, [10] = d6, Bob's ZK proof that pb, qb formed correctly 
      * @param bstate MVN_PASS_JAVADOC_INSPECTION
      * @param secret MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
      */
-	public static byte[] step2b(SMState bstate, byte[] secret) throws SMException
+	public static byte[] step2b(SMState bstate, byte[] secret, SecureRandom sr) throws SMException
 	{
 	    /* Convert the given secret to the proper form and store it */
 		//Util.checkBytes("secret", secret);
@@ -521,17 +527,17 @@ public class SM {
 
 	    BigInteger[] msg2 = new BigInteger[11];
 	    msg2[0] = bstate.g1.modPow(bstate.x2, MODULUS_S);
-	    BigInteger[] res = proofKnowLog(bstate.g1,bstate.x2,3);
+	    BigInteger[] res = proofKnowLog(bstate.g1, bstate.x2, 3, sr);
 	    msg2[1]=res[0];
 	    msg2[2]=res[1];
 
 	    msg2[3] = bstate.g1.modPow(bstate.x3, MODULUS_S);
-	    res = proofKnowLog(bstate.g1,bstate.x3,4);
+	    res = proofKnowLog(bstate.g1, bstate.x3, 4, sr);
 	    msg2[4]=res[0];
 	    msg2[5]=res[1];
 
 	    /* Calculate P and Q values for Bob */
-	    BigInteger r = randomExponent();
+	    BigInteger r = randomExponent(sr);
 	    //BigInteger r = new BigInteger(SM.GENERATOR_S);
 
 	    bstate.p = bstate.g3.modPow(r, MODULUS_S);
@@ -547,7 +553,7 @@ public class SM {
 	    //Util.checkBytes("Qb", bstate.q.getValue());
 	    msg2[7] = bstate.q;
 	    
-	    res = proofEqualCoords(bstate, r, 5);
+	    res = proofEqualCoords(bstate, r, 5, sr);
 	    msg2[8]=res[0];
 	    msg2[9]=res[1];
 	    msg2[10]=res[2];
@@ -565,10 +571,11 @@ public class SM {
 	 * [6] = cr, [7] = d7, Alice's ZK proof that ra is formed correctly 
      * @param astate MVN_PASS_JAVADOC_INSPECTION
      * @param input MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
      */
-	public static byte[] step3(SMState astate, byte[] input) throws SMException
+	public static byte[] step3(SMState astate, byte[] input, SecureRandom sr) throws SMException
 	{
 	    /* Read from input to find the mpis */
 	    astate.smProgState = PROG_CHEATED;
@@ -603,7 +610,7 @@ public class SM {
 	    	throw new SMException("Invalid Parameter");
 
 	    /* Calculate P and Q values for Alice */
-	    BigInteger r = randomExponent();
+	    BigInteger r = randomExponent(sr);
 	    //BigInteger r = new BigInteger(SM.GENERATOR_S);
 
 	    astate.p = astate.g3.modPow(r, MODULUS_S);
@@ -619,7 +626,7 @@ public class SM {
 	    msg3[1] = astate.q;
 	    //Util.checkBytes("Qa", astate.q.getValue());
 	    
-	    BigInteger[] res = proofEqualCoords(astate,r,6);
+	    BigInteger[] res = proofEqualCoords(astate, r, 6, sr);
 	    msg3[2] = res[0];
 	    msg3[3] = res[1];
 	    msg3[4] = res[2];
@@ -631,7 +638,7 @@ public class SM {
 	    inv = msg2[7].modInverse(MODULUS_S);
 	    astate.qab = astate.q.multiply(inv).mod(MODULUS_S);
 	    msg3[5] = astate.qab.modPow(astate.x3, MODULUS_S);
-	    res = proofEqualLogs(astate, 7);
+	    res = proofEqualLogs(astate, 7, sr);
 	    msg3[6]=res[0];
 	    msg3[7]=res[1];
 	    
@@ -652,10 +659,11 @@ public class SM {
      *
      * @param bstate MVN_PASS_JAVADOC_INSPECTION
      * @param input MVN_PASS_JAVADOC_INSPECTION
+     * @param sr SecureRandom instance
      * @return MVN_PASS_JAVADOC_INSPECTION
 	 * @throws SMException MVN_PASS_JAVADOC_INSPECTION
      */
-	public static byte[] step4(SMState bstate, byte[] input) throws SMException
+	public static byte[] step4(SMState bstate, byte[] input, SecureRandom sr) throws SMException
 	{
 	    /* Read from input to find the mpis */
 	    BigInteger[] msg3 = unserialize(input);
@@ -688,7 +696,7 @@ public class SM {
 
 	    /* Calculate Rb and proof */
 	    msg4[0] = bstate.qab.modPow(bstate.x3, MODULUS_S);
-	    BigInteger[] res = proofEqualLogs(bstate,8);
+	    BigInteger[] res = proofEqualLogs(bstate, 8, sr);
 	    msg4[1]=res[0];
 	    msg4[2]=res[1];
 	    

--- a/src/main/java/net/java/otr4j/session/AuthContext.java
+++ b/src/main/java/net/java/otr4j/session/AuthContext.java
@@ -12,7 +12,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.KeyPair;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Vector;
 import java.util.logging.Logger;
@@ -60,7 +59,6 @@ public class AuthContext {
     // If the Session that this AuthContext belongs to is the 'master' session
     // then these parameters must be replicated to all slave session's auth
     // contexts.
-    SecureRandom secureRandom;
     byte[] r;
     KeyPair localDHKeyPair;
     byte[] localDHPublicKeyBytes;
@@ -230,12 +228,10 @@ public class AuthContext {
     }
 
     private byte[] getR() {
-        if (secureRandom == null)
-            secureRandom = new java.security.SecureRandom();
         if (r == null) {
             logger.finest("Picking random key r.");
             r = new byte[OtrCryptoEngine.AES_KEY_BYTE_LENGTH];
-            secureRandom.nextBytes(r);
+            this.session.secureRandom().nextBytes(r);
         }
         return r;
     }
@@ -278,7 +274,7 @@ public class AuthContext {
 
     public KeyPair getLocalDHKeyPair() throws OtrException {
         if (localDHKeyPair == null) {
-            localDHKeyPair = OtrCryptoEngine.generateDHKeyPair();
+            localDHKeyPair = OtrCryptoEngine.generateDHKeyPair(this.session.secureRandom());
             logger.finest("Generated local D-H key pair.");
         }
         return localDHKeyPair;

--- a/src/main/java/net/java/otr4j/session/InstanceTag.java
+++ b/src/main/java/net/java/otr4j/session/InstanceTag.java
@@ -4,6 +4,9 @@ import java.security.SecureRandom;
 
 public class InstanceTag {
 
+    /**
+     * Zero-value.
+     */
 	public static final int ZERO_VALUE = 0;
 
 	/**
@@ -12,15 +15,24 @@ public class InstanceTag {
 	public static final int SMALLEST_VALUE = 0x00000100;
 
 	/**
-	 * The highest possible tag value.
+	 * The largest possible tag value.
 	 * Note that this is -1 in the decimal representation.
 	 */
 	public static final int HIGHEST_VALUE = 0xffffffff;
 
+    /**
+     * Zero-value instance tag.
+     */
 	public static final InstanceTag ZERO_TAG = new InstanceTag(ZERO_VALUE);
 
+    /**
+     * Smallest valid instance tag.
+     */
 	public static final InstanceTag SMALLEST_TAG = new InstanceTag(SMALLEST_VALUE);
 
+    /**
+     * Largest valid instance tag.
+     */
 	public static final InstanceTag HIGHEST_TAG = new InstanceTag(HIGHEST_VALUE);
 
 	/**
@@ -43,6 +55,16 @@ public class InstanceTag {
 		// 32 bits of memory is acceptable.
 		return !(0 < tagValue && tagValue < SMALLEST_VALUE);
 	}
+
+    /**
+     * Create a new randomly generated instance tag.
+     *
+     * @param random Secure random instance to use for generating.
+     * @return Returns new randomly generated Instance tag instance.
+     */
+    public static InstanceTag random(final SecureRandom random) {
+        return new InstanceTag(random.nextDouble());
+    }
 
 	/**
 	 * The default constructor for Instance Tag.
@@ -81,16 +103,16 @@ public class InstanceTag {
 		this.value = (int)val;
 	}
 
-	public int getValue() {
-		return value;
-	}
-
 	InstanceTag(final int value) {
 		if (!isValidInstanceTag(value))
 		{
 			throw new IllegalArgumentException("Invalid tag value.");
 		}
 		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
 	}
 
 	@Override

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -109,7 +109,7 @@ public class Session {
         this.sessionStatus = SessionStatus.PLAINTEXT;
         this.offerStatus = OfferStatus.idle;
 
-        this.senderTag = new InstanceTag(this.secureRandom.nextDouble());
+        this.senderTag = InstanceTag.random(this.secureRandom);
         this.receiverTag = InstanceTag.ZERO_TAG;
 
         slaveSessions = new HashMap<InstanceTag, Session>();

--- a/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
+++ b/src/main/java/net/java/otr4j/session/SmpTlvHandler.java
@@ -137,9 +137,9 @@ public class SmpTlvHandler {
 		byte[] smpmsg;
 		try {
 			if (initiating) {
-				smpmsg = SM.step1(smstate, combined_secret);
+				smpmsg = SM.step1(smstate, combined_secret, this.session.secureRandom());
 			} else {
-				smpmsg = SM.step2b(smstate, combined_secret);
+				smpmsg = SM.step2b(smstate, combined_secret, this.session.secureRandom());
 			}
 		} catch (SMException ex) {
 			throw new OtrException(ex);
@@ -202,7 +202,7 @@ public class SmpTlvHandler {
 			byte[] input = new byte[question.length-qlen];
 			System.arraycopy(question, qlen, input, 0, question.length-qlen);
 			try {
-				SM.step2a(smstate, input, 1);
+				SM.step2a(smstate, input, 1, this.session.secureRandom());
 			} catch (SMException e) {
 				throw new OtrException(e);
 			}
@@ -235,7 +235,7 @@ public class SmpTlvHandler {
 			 * We must wait for the secret to be entered
 			 * to continue. */
 			try {
-				SM.step2a(smstate, tlv.getValue(), 0);
+				SM.step2a(smstate, tlv.getValue(), 0, this.session.secureRandom());
 			} catch (SMException e) {
 				throw new OtrException(e);
 			}
@@ -256,7 +256,7 @@ public class SmpTlvHandler {
 	    if (smstate.nextExpected == SM.EXPECT2) {
 			byte[] nextmsg;
 			try {
-				nextmsg = SM.step3(smstate, tlv.getValue());
+				nextmsg = SM.step3(smstate, tlv.getValue(), this.session.secureRandom());
 			} catch (SMException e) {
 				throw new OtrException(e);
 			}
@@ -282,7 +282,7 @@ public class SmpTlvHandler {
         if (smstate.nextExpected == SM.EXPECT3) {
 			byte[] nextmsg;
 			try {
-				nextmsg = SM.step4(smstate, tlv.getValue());
+				nextmsg = SM.step4(smstate, tlv.getValue(), this.session.secureRandom());
 			} catch (SMException e) {
 				throw new OtrException(e);
 			}

--- a/src/test/java/net/java/otr4j/io/IOTest.java
+++ b/src/test/java/net/java/otr4j/io/IOTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.SecureRandom;
 
 import javax.crypto.interfaces.DHPublicKey;
 
@@ -16,6 +17,8 @@ import net.java.otr4j.io.messages.RevealSignatureMessage;
 import net.java.otr4j.session.Session.OTRv;
 
 public class IOTest {
+
+    private final SecureRandom secureRandom = new SecureRandom();
 
 	public interface EncodedMessageTextSample {
 
@@ -93,7 +96,7 @@ public class IOTest {
 	@Test
 	public void testIOBigInt() throws Exception {
 
-		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair(this.secureRandom);
 		BigInteger source = ((DHPublicKey) pair.getPublic()).getY();
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -119,7 +122,7 @@ public class IOTest {
 
 	@Test
 	public void testIODHPublicKey() throws Exception {
-		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair(this.secureRandom);
 
 		DHPublicKey source = (DHPublicKey) pair.getPublic();
 
@@ -146,7 +149,7 @@ public class IOTest {
 
 	@Test
 	public void testIODHKeyMessage() throws Exception {
-		KeyPair pair = OtrCryptoEngine.generateDHKeyPair();
+		KeyPair pair = OtrCryptoEngine.generateDHKeyPair(this.secureRandom);
 
 		DHKeyMessage source = new DHKeyMessage(OTRv.THREE, (DHPublicKey) pair
 				.getPublic());


### PR DESCRIPTION
Details are in the commit message. Basically, I've moved the SecureRandom instance into the Session instance. It is accessible by other classes inside the package, i.e. the secureRandom() method is package-private. For methods in other packages, such as the crypto classes, I have added a SecureRandom parameter such that we can pass it on for temporary use.

The SecureRandom instance is created immediately upon initializing the Session instance. This is needed in any case for the InstanceTag that is created. By sharing the SecureRandom instance, we only need to create it once.

It is not a good idea to share the SecureRandom instance over threads. It is thread-safe (IIRC) but we can just as easily use separate instance for this. That is why I believe the Session is the correct granularity as well as that it keeps operation single-threaded.

I have not had the opportunity to test this with a chat client. However the tests all pass and these are by and large syntax-related changes which are checked by the IDE. Let me know if additional testing is required.
