### PR TITLE
Restructure slave sessions

### DIFF
--- a/src/main/java/net/java/otr4j/util/SelectableMap.java
+++ b/src/main/java/net/java/otr4j/util/SelectableMap.java
@@ -1,0 +1,167 @@
+package net.java.otr4j.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Map wrapper that additionally stores which item is selected. The selection
+ * may be null. If it is not null, then the key must exist in the provided base
+ * map.
+ *
+ * @author Danny van Heumen
+ * @param <K> Key type
+ * @param <V> Value type
+ */
+public class SelectableMap<K, V> implements Map<K, V>
+{
+	/**
+	 * Map instance that is at the basis of the selectable map.
+	 */
+	private final Map<K, V> base;
+
+	/**
+	 * Indicates that a selection is made.
+	 *
+	 * If true, then a selection is made, even if the selected key is null.
+	 */
+	private volatile boolean selected;
+
+	/**
+	 * The key of the selected entry in the map.
+	 */
+	private volatile K selection;
+
+	/**
+	 * Create a selectable map without initial selection.
+	 *
+	 * @param base the base map
+	 */
+	public SelectableMap(Map<K, V> base) {
+		if (base == null)
+		{
+			throw new NullPointerException("base");
+		}
+		this.base = base;
+                this.selection = null;
+                this.selected = false;
+	}
+
+	/**
+	 * Create a selectable map with initial selection.
+	 *
+	 * @param base the base map
+	 * @param selected the initially selected entry
+	 */
+	public SelectableMap(Map<K, V> base, K selected)
+	{
+		this(base);
+		select(selected);
+	}
+
+	@Override
+	public int size()
+	{
+		return base.size();
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return base.isEmpty();
+	}
+
+	@Override
+	public boolean containsKey(Object key)
+	{
+		return base.containsKey(key);
+	}
+
+	@Override
+	public boolean containsValue(Object value)
+	{
+		return base.containsValue(value);
+	}
+
+	@Override
+	public V get(Object key)
+	{
+		return base.get(key);
+	}
+
+	@Override
+	public V put(K key, V value)
+	{
+		return base.put(key, value);
+	}
+
+	@Override
+	public V remove(Object key)
+	{
+		if (isSelected() && this.selection.equals(key))
+		{
+			deselect();
+		}
+		return base.remove(key);
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> m)
+	{
+		base.putAll(m);
+	}
+
+	@Override
+	public void clear()
+	{
+		deselect();
+		base.clear();
+	}
+
+	@Override
+	public Set<K> keySet()
+	{
+		return Collections.unmodifiableSet(base.keySet());
+	}
+
+	@Override
+	public Collection<V> values()
+	{
+		return Collections.unmodifiableCollection(base.values());
+	}
+
+	@Override
+	public Set<Entry<K, V>> entrySet()
+	{
+		return Collections.unmodifiableSet(base.entrySet());
+	}
+
+	public final boolean isSelected()
+	{
+		return this.selected;
+	}
+
+	public final V getSelected()
+	{
+		if (!this.selected)
+		{
+			throw new IllegalStateException("no selection available");
+		}
+		return base.get(this.selection);
+	}
+
+	public final void select(K key)
+	{
+		// verify that key exists before changing selected
+		if (!base.containsKey(key)) {
+			throw new IllegalArgumentException("key is not in base map");
+		}
+		this.selection = key;
+		this.selected = true;
+	}
+
+	public final void deselect() {
+		this.selected = false;
+	}
+}


### PR DESCRIPTION
There is a specific subset of Session state which is highly related / tightly coupled, which is: 1. not obvious as such, 2. not documented as such, 3. not very well enforced as such, originally. This patch introduces a collection that composes the 2 pieces into a separate class and enforces sane restrictions in order to keep the two variables "in sync" / consistent.

The collection _slaveSessions_ and the _outgoingSession_ variable are both used in managing slave sessions. The _outgoingSession_ variable actually contains one of the instances in _slaveSessions_, i.e. the one that is selected as the default outgoing session in cases of sending, where a slave session may be used.

The SelectableMap wrapper composes the two and therefore has the following advantages:
- Separates this tightly coupled piece of state. (Structurally)
- Code and method naming makes its intention obvious and ensures that relation is obvious/unmistakeable
- Sane restrictions are enforced such that it is impossible to select a session that is not in the collection, or if you intend to delete a session, forget to clear it from "outgoingSession". It prevents marking of session "instance" (null or invalid in some other way) as default while it is not known by this slave sessions collection.

(This is a port of the patch that I originally committed to jitsi/otr4j.)
