### PR TITLE
Fixed bad comparisons for 'checkGroupElem' and 'checkExpon' basic ver…

### DIFF
--- a/src/main/java/net/java/otr4j/crypto/SM.java
+++ b/src/main/java/net/java/otr4j/crypto/SM.java
@@ -208,8 +208,7 @@ public class SM {
      */
 	public static boolean checkGroupElem(BigInteger g)
 	{
-		return !(g.compareTo(BigInteger.valueOf(2)) > 0 &&
-				g.compareTo(SM.MODULUS_MINUS_2) < 0);
+		return g.compareTo(BigInteger.valueOf(2)) < 0 || g.compareTo(SM.MODULUS_MINUS_2) > 0;
 	}
 	
 	/**
@@ -221,7 +220,7 @@ public class SM {
      */
 	public static boolean checkExpon(BigInteger x)
 	{
-		return !(x.compareTo(BigInteger.ONE) > 0 && x.compareTo(SM.ORDER_S) <= 0);
+		return x.compareTo(BigInteger.ONE) < 0 || x.compareTo(SM.ORDER_S) >= 0;
 	}
 	
 	/**

--- a/src/test/java/net/java/otr4j/crypto/SMTest.java
+++ b/src/test/java/net/java/otr4j/crypto/SMTest.java
@@ -1,0 +1,63 @@
+package net.java.otr4j.crypto;
+
+import java.math.BigInteger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for Socialist Millionaire Protocol.
+ *
+ * @author Danny van Heumen
+ */
+public class SMTest {
+
+    @Test
+    public void testCheckGroupElemValid() throws SM.SMException {
+        assertFalse(SM.checkGroupElem(BigInteger.TEN));
+    }
+
+    @Test
+    public void testCheckGroupElemJustValidLowerBound() throws SM.SMException {
+        assertFalse(SM.checkGroupElem(BigInteger.valueOf(2l)));
+    }
+
+    @Test
+    public void testCheckGroupElemTooSmall() throws SM.SMException {
+        assertTrue(SM.checkGroupElem(BigInteger.ONE));
+    }
+
+    @Test
+    public void testCheckGroupElemJustValidUpperBound() throws SM.SMException {
+        assertFalse(SM.checkGroupElem(SM.MODULUS_MINUS_2));
+    }
+
+    @Test
+    public void testCheckGroupElemTooLarge() throws SM.SMException {
+        assertTrue(SM.checkGroupElem(SM.MODULUS_MINUS_2.add(BigInteger.ONE)));
+    }
+
+    @Test
+    public void testCheckExponValid() throws SM.SMException {
+        assertFalse(SM.checkExpon(BigInteger.TEN));
+    }
+
+    @Test
+    public void testCheckExponJustValidLowerBound() throws SM.SMException {
+        assertFalse(SM.checkExpon(BigInteger.ONE));
+    }
+
+    @Test
+    public void testCheckExponTooSmall() throws SM.SMException {
+        assertTrue(SM.checkExpon(BigInteger.ZERO));
+    }
+
+    @Test
+    public void testCheckExponJustValidUpperBound() throws SM.SMException {
+        assertFalse(SM.checkExpon(SM.ORDER_S.subtract(BigInteger.ONE)));
+    }
+
+    @Test
+    public void testCheckExponTooLarge() throws SM.SMException {
+        assertTrue(SM.checkExpon(SM.ORDER_S));
+    }
+}


### PR DESCRIPTION
…ification methods for parameters in SMP.

The methods 'checkGroupElem' and 'checkExpon' are basic methods that are
used to verify parameters of SMP. These methods used bad boundary
conditions when checking values. As a result, some valid values were
flagged as invalid parameters while others were wrongly accepted.

A number of tests are included that check values next to the boundaries
to ensure that verification is executed correctly.

As part of looking into these errors, I have verified the other methods
of SM.java. Apart from 'checkGroupElem' and 'checkExpon' all methods
match their counterparts in java-otr and libotr. (AFAICT)
