### PR TITLE
Added git ignore patterns for Gradle, Netbeans, IntelliJ.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,18 @@ target/
 *.orig
 otr.properties
 
+# Gradle
+/build
+/.gradle
+
+# Netbeans
+/nb-configuration.xml
+/nbproject
+
+# IntelliJ
+/.idea
+/*.iml
+
 # Android build products
 gen/
 build.xml


### PR DESCRIPTION
Added ignore patterns for:
- Gradle (cache/build directories)
- Netbeans (project management files/directories)
- IntelliJ (project management files/directories)
