### PR TITLE
Interoperability: Instancetag parsing bug (OtrAssembler chokes on 32-bit instance tag)

### DIFF
--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -75,7 +75,7 @@ public final class OtrAssembler {
 			msgText = msgText.substring(
 					HEAD_FRAGMENT_V2.length());
 		} else if (msgText.startsWith(HEAD_FRAGMENT_V3)) {
-			// v
+			// v3
 			msgText = msgText.substring(
 					HEAD_FRAGMENT_V3.length());
 

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -106,7 +106,9 @@ public final class OtrAssembler {
 				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
 
-            // FIXME should we also verify that the sender instance tag of the fragment is valid? The sender instance tag is now ignored completely.
+            // currently sender instance tag is not verified, as we also have no
+            // use for that instance tag. It is sufficient to know that the
+            // message fragment is intended for us, i.e. receiver instance tag.
 
 			if (receiverInstance != 0 &&
 					receiverInstance != ownInstance.getValue()) {
@@ -133,10 +135,10 @@ public final class OtrAssembler {
 			n = Integer.parseInt(params[1]);
 		} catch (NumberFormatException e) {
 			discard();
-			throw new ProtocolException("Bad format for parameters");
+			throw new ProtocolException("Bad format for parameter current/total fragment number");
 		} catch (ArrayIndexOutOfBoundsException e) {
 			discard();
-			throw new ProtocolException("Expected at least 2 parameters");
+			throw new ProtocolException("Expected 2 parameters: current and total fragment numbers");
 		}
 
 		if (k <= 0 || k > MAX_FRAGMENTS || n <= 0 || n > MAX_FRAGMENTS || k > n

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -16,7 +16,9 @@ import java.net.ProtocolException;
  */
 public final class OtrAssembler {
 
-	public OtrAssembler(InstanceTag ownInstance) {
+    private static final int MAX_FRAGMENTS = 65535;
+
+	public OtrAssembler(final InstanceTag ownInstance) {
 		this.ownInstance = ownInstance;
 		discard();
 	}
@@ -137,9 +139,9 @@ public final class OtrAssembler {
 			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
-        // FIXME verify maximum value of 65535 for k, n
-        // FIXME disallow values < 0 too!
-		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
+		if (k <= 0 || k > MAX_FRAGMENTS || n <= 0 || n > MAX_FRAGMENTS || k > n
+                || params.length != 4 || params[2].isEmpty()
+                || !params[3].isEmpty()) {
 			discard();
 			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");
 		}

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -87,13 +87,25 @@ public final class OtrAssembler {
 				throw new ProtocolException();
 			}
 
-			int receiverInstance;
+            // parse receiver instance tag
+			final int receiverInstance;
 			try {
+                // Verify length before parsing as BigInteger, as BigInteger
+                // will support much larger tag values even though they are not
+                // valid according to spec. With conversion to int they will be
+                // truncated without warning, so we need to discover invalid
+                // tags before parsing.
+                if (instances[1].length() > 8) {
+                    throw new ProtocolException("Invalid receiver instance id: " + instances[1] + ". Instance tag is too big.");
+                }
 				receiverInstance = new BigInteger(instances[1], 16).intValue();
 			} catch (NumberFormatException e) {
 				discard();
 				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
+
+            // FIXME should we also verify that the sender instance tag of the fragment is valid? The sender instance tag is now ignored completely.
+
 			if (receiverInstance != 0 &&
 					receiverInstance != ownInstance.getValue()) {
 				// discard message for different instance id
@@ -125,6 +137,8 @@ public final class OtrAssembler {
 			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
+        // FIXME verify maximum value of 65535 for k, n
+        // FIXME disallow values < 0 too!
 		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
 			discard();
 			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -6,6 +6,7 @@
  */
 package net.java.otr4j.session;
 
+import java.math.BigInteger;
 import java.net.ProtocolException;
 
 /**
@@ -88,10 +89,10 @@ public final class OtrAssembler {
 
 			int receiverInstance;
 			try {
-				receiverInstance = Integer.parseInt(instances[1], 16);
+				receiverInstance = new BigInteger(instances[1], 16).intValue();
 			} catch (NumberFormatException e) {
 				discard();
-				throw new ProtocolException();
+				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
 			if (receiverInstance != 0 &&
 					receiverInstance != ownInstance.getValue()) {
@@ -118,15 +119,15 @@ public final class OtrAssembler {
 			n = Integer.parseInt(params[1]);
 		} catch (NumberFormatException e) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Bad format for parameters");
 		} catch (ArrayIndexOutOfBoundsException e) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
 		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");
 		}
 
 		msgText = params[2];

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.crypto.interfaces.DHPublicKey;
@@ -350,7 +351,7 @@ public class Session {
             getHost().messageFromAnotherInstanceReceived(getSessionID());
             return null;
         } catch (ProtocolException e) {
-            logger.warning("An invalid message fragment was discarded.");
+            logger.log(Level.WARNING, "An invalid message fragment was discarded.", e);
             return null;
         }
 

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -1,0 +1,37 @@
+/*
+ * otr4j, the open source java otr library.
+ *
+ * Distributable under LGPL license.
+ * See terms of license at gnu.org.
+ */
+package net.java.otr4j.session;
+
+import java.net.ProtocolException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for OTR Assembler.
+ *
+ * @author Danny van Heumen
+ */
+public class OtrAssemblerTest {
+
+    @Test
+    public void testCorrectParsingOf32bitsInteger() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(data));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDiscardingOf33bitsInteger() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|1%08x,00001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    // FIXME test empty content in fragment (should give ProtocolException)
+}

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -26,12 +26,66 @@ public class OtrAssemblerTest {
     }
 
     @Test(expected = ProtocolException.class)
-    public void testCorrectDiscardingOf33bitsInteger() throws ProtocolException {
+    public void testCorrectDisallowOf33bitsInteger() throws ProtocolException {
         final InstanceTag tag = new InstanceTag(0.99999645d);
         final String data = String.format("?OTR|ff123456|1%08x,00001,00002,test,", tag.getValue());
         final OtrAssembler ass = new OtrAssembler(tag);
         ass.accumulate(data);
     }
 
-    // FIXME test empty content in fragment (should give ProtocolException)
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowEmptyPayload() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowTrailingData() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,test,invalid", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowNegativeK() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,-0001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowKLargerThanN() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00003,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowKOverUpperBound() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,65536,65536,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test
+    public void testCorrectMaximumNFragments() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00001,65535,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(data));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowNOverUpperBound() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0.99999645d);
+        final String data = String.format("?OTR|ff123456|%08x,00001,65536,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
 }

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -7,6 +7,7 @@
 package net.java.otr4j.session;
 
 import java.net.ProtocolException;
+import java.security.SecureRandom;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -16,6 +17,8 @@ import static org.junit.Assert.*;
  * @author Danny van Heumen
  */
 public class OtrAssemblerTest {
+
+    private static final SecureRandom RAND = new SecureRandom();
 
     @Test
     public void testCorrectParsingOf32bitsInteger() throws ProtocolException {
@@ -87,5 +90,31 @@ public class OtrAssemblerTest {
         final String data = String.format("?OTR|ff123456|%08x,00001,65536,test,", tag.getValue());
         final OtrAssembler ass = new OtrAssembler(tag);
         ass.accumulate(data);
+    }
+
+    @Test
+    public void testAssembleSinglePartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(RAND.nextDouble());
+        final String data = String.format("?OTR|ff123456|%08x,00001,00001,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertEquals("test", ass.accumulate(data));
+    }
+
+    @Test
+    public void testAssembleTwoPartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(RAND.nextDouble());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00001,00002,abcdef,", tag.getValue())));
+        assertEquals("abcdefghijkl", ass.accumulate(String.format("?OTR|ff123456|%08x,00002,00002,ghijkl,", tag.getValue())));
+    }
+
+    @Test
+    public void testAssembleFourPartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(RAND.nextDouble());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00001,00004,a,", tag.getValue())));
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00002,00004,b,", tag.getValue())));
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00003,00004,c,", tag.getValue())));
+        assertEquals("abcd", ass.accumulate(String.format("?OTR|ff123456|%08x,00004,00004,d,", tag.getValue())));
     }
 }


### PR DESCRIPTION
A bug exists in the OtrAssembler that chokes on 32-bit instance tags in OTRv3 fragments. Very specific details are in the comments and commit logs.

In general, Integer.parseInt(...) can only parse integer values up to 31 bits, even if they are hexadecimal values. A 32-bit value will result in an exception being thrown. By parsing the instance tag as BigInteger and then extracting the lowest 32 bits as int primitive, we can parse the full instance tag.
