### PR TITLE
Work-around for persisting buffer overflow error with OpenJDK 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,14 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
+
+# Workaround for https://github.com/travis-ci/travis-ci/issues/5227
+# Buffer overflow in Java_java_net_Inet4AddressImpl_getLocalHostName
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
+
 install: mvn install -DskipTests=true
 script: mvn test


### PR DESCRIPTION
Workaround for travis-ci OpenJDK 7 buffer overflow issue.
