### PR TITLE
Fix startSession condition when evaluating OTR policy.

### DIFF
--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -974,9 +974,9 @@ public class Session {
         if (this.getSessionStatus() == SessionStatus.ENCRYPTED)
             return;
 
-        if (!getSessionPolicy().getAllowV2() || !getSessionPolicy().getAllowV3())
-            throw new UnsupportedOperationException();
-
+        if (!getSessionPolicy().getAllowV2() && !getSessionPolicy().getAllowV3()) {
+            throw new UnsupportedOperationException("No valid options left in OTR policy for starting a new OTR session.");
+        }
         this.getAuthContext().startAuth();
     }
 


### PR DESCRIPTION
The original if-condition stated that if either OTRv2 or OTRv3 is
disabled in the active OTR policy, then we should throw an
UnsupportedOperationException. This does not make sense, since if
either one of the versions is disabled by the policy, we can still fall
back on the other option.
What we should want is that if both OTRv2 and OTRv3 is not an option
because both are disabled, then we have no fallback option and _then_ we
throw an UnsupportedOperationException stating that we have no valid
options left.
