### PR TITLE
Explicit serial number in exceptions.

### DIFF
--- a/src/main/java/net/java/otr4j/OtrException.java
+++ b/src/main/java/net/java/otr4j/OtrException.java
@@ -1,8 +1,8 @@
 
 package net.java.otr4j;
 
-@SuppressWarnings("serial")
 public class OtrException extends Exception {
+    private static final long serialVersionUID = -6327624437614707245L;
 
     public OtrException(Exception e) {
         super(e);

--- a/src/main/java/net/java/otr4j/crypto/OtrCryptoException.java
+++ b/src/main/java/net/java/otr4j/crypto/OtrCryptoException.java
@@ -2,8 +2,8 @@ package net.java.otr4j.crypto;
 
 import net.java.otr4j.OtrException;
 
-@SuppressWarnings("serial")
 public class OtrCryptoException extends OtrException {
+    private static final long serialVersionUID = -2636945817636034632L;
 
 	public OtrCryptoException(Exception e) {
 		super(e);

--- a/src/main/java/net/java/otr4j/session/UnknownInstanceException.java
+++ b/src/main/java/net/java/otr4j/session/UnknownInstanceException.java
@@ -2,11 +2,10 @@ package net.java.otr4j.session;
 
 import java.net.ProtocolException;
 
-@SuppressWarnings("serial")
 public class UnknownInstanceException extends ProtocolException {
+    private static final long serialVersionUID = -9038076875471875721L;
 
 	public UnknownInstanceException(String host) {
 		super(host);
 	}
-
 }


### PR DESCRIPTION
Make serial number in exceptions explicit as it would otherwise be
generated on the fly anyways. This way we can be sure that every JVM
behaves the same way, uses the same serial number.
Even if this is not a big deal, consistency is a good thing.
