### PR TITLE
toMessage ?OTR fix crashing/erroring. More specification conformity.

### DIFF
--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -308,7 +308,15 @@ public class SerializationUtils {
 					// the clients willingness to conform to this standard.
 					versions.add(OTRv.ONE);
 				} else if (SerializationConstants.HEAD_QUERY_V == contentType) {
-					versionString = content.substring(0, content.indexOf('?'));
+					// ?OTRvX? Format
+
+					// Check for a trailing ? character, otherwise the OTR message is invalid.
+					if(content.isEmpty() || content.charAt(content.length() - 1) != '?') {
+						return new ErrorMessage(AbstractMessage.MESSAGE_ERROR, "Invalid OTR Format!");
+					}
+					else {
+						versionString = content.substring(0, content.indexOf('?'));
+					}
 				}
 
 				if (versionString != null) {

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -302,11 +302,11 @@ public class SerializationUtils {
 				LinkedHashSet<Integer> versions = new LinkedHashSet<Integer>();
 				String versionString = null;
 				if (SerializationConstants.HEAD_QUERY_Q == contentType) {
+					// ?OTR? specifies conformity to Version 1.
+					// Version numbers cannot follow a trailing '?' character.
+					// Therefore, this block can only show conformity to OTRv1, and shows
+					// the clients willingness to conform to this standard.
 					versions.add(OTRv.ONE);
-					if (content.charAt(0) == 'v') {
-						versionString = content.substring(1, content
-								.indexOf('?'));
-					}
 				} else if (SerializationConstants.HEAD_QUERY_V == contentType) {
 					versionString = content.substring(0, content.indexOf('?'));
 				}

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -278,6 +278,11 @@ public class SerializationUtils {
 			// Message **contains** the string "?OTR". Check to see if it is an error message, a query message or a data
 			// message.
 
+			// Message == "?OTR" check. As this will cause OutOfBounds on s.charAt call.
+			if((idxHead + SerializationConstants.HEAD.length()) >= s.length()){
+				return new ErrorMessage(AbstractMessage.MESSAGE_ERROR, "Blank ?OTR message received.");
+			}
+
 			char contentType = s.charAt(idxHead + SerializationConstants.HEAD.length());
 			String content = s
 					.substring(idxHead + SerializationConstants.HEAD.length() + 1);

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -15,6 +15,7 @@ import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.security.PublicKey;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Vector;
 import java.util.regex.Matcher;
@@ -292,7 +293,8 @@ public class SerializationUtils {
 					|| contentType == SerializationConstants.HEAD_QUERY_Q) {
 				// Query tag found.
 
-				List<Integer> versions = new Vector<Integer>();
+				// LinkedHashSet ensures that each item is unique, as required by the OTRv3 Specification.
+				LinkedHashSet<Integer> versions = new LinkedHashSet<Integer>();
 				String versionString = null;
 				if (SerializationConstants.HEAD_QUERY_Q == contentType) {
 					versions.add(OTRv.ONE);
@@ -312,7 +314,8 @@ public class SerializationUtils {
 							versions.add(Integer.parseInt(String
 									.valueOf((char) c)));
 				}
-				QueryMessage query = new QueryMessage(versions);
+				// Create a concrete Type from the Abstract List for QueryMessage, passing in our unique collection.
+				QueryMessage query = new QueryMessage(new ArrayList<Integer>(versions));
 				return query;
 			} else if (idxHead == 0 && contentType == SerializationConstants.HEAD_ENCODED) {
 				// Data message found.


### PR DESCRIPTION
Having had this issue working with redsolution/xabber-android.

I opened an issue at redsolution/xabber-android#652 linking what appeared to be a related bug in redsolution/xabber-android#329. Yes resolution have their own fork of otr4j, but their recent xabber-android points the submodule to your repository.
Therefore I apologise for the convoluted way in which this appears to arrive, as it comes from my organisational repository as well.
This is a long standing bug that causes fatal errors in applications which utilise otr4j ( particularly xabber-android ) - Where manual message passing can result in consistent client crash states.

The primary concerns in this was that clients can send text to the user in the form of `?OTR`, `?OTR?` and `?OTRv`, all of which don't exactly conform to the specification one way or the other, with some of those mechanisms causing OutOfBounds Exceptions.
I sought to fix these by rewriting checks within AbstractMessage toMessage method, and ensuring that charAt cannot be called within invalid input. 
Two new Error Messages can be produced for Blank OTR, input `?OTR` and Invalid OTR, for `?OTRv` without a closing ?.
From brief testing with @Xandaros and some personal testing of my own, I believe I have resolved the crashes as discovered in redsolution/xabber-android as a result of your otr4j implementation.
ToMessage should now more closely conform to the OTRv3 Standard for message format and parsing, and be more rigorous to errors arising due to incorrectly formatted manually messages.

I am somewhat new to the OTR Specification, so please feel free to let me know if there are any issues with the suggested solution, or if you wish to discuss the error mechanism, if they should be silent, etc.

Regards,
Ashley Williamson
